### PR TITLE
build: machine-readable export + CI integrity checks

### DIFF
--- a/.github/workflows/integrity.yml
+++ b/.github/workflows/integrity.yml
@@ -1,0 +1,31 @@
+name: AATMF Integrity
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  integrity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Validate framework integrity
+        run: python scripts/validate.py
+
+      - name: Verify machine-readable export is current
+        run: |
+          python scripts/build_export.py
+          if ! git diff --quiet -- data/; then
+            echo "::error::data/ export is out of date. Run 'python scripts/build_export.py' and commit the result."
+            git --no-pager diff -- data/
+            exit 1
+          fi

--- a/data/aatmf-techniques.csv
+++ b/data/aatmf-techniques.csv
@@ -1,0 +1,241 @@
+tactic_id,tactic,technique_id,title,risk_score,rating,procedures,owasp_llm,mitre_atlas
+T1,Prompt & Context Subversion,T1-AT-001,Dialogue Hijacking,220,HIGH,5,LLM01,AML.T0051
+T1,Prompt & Context Subversion,T1-AT-002,Time-Based Context Manipulation,210,HIGH,5,LLM01,AML.T0051.001
+T1,Prompt & Context Subversion,T1-AT-003,Language Model Confusion,225,HIGH,5,LLM01,AML.T0051.001
+T1,Prompt & Context Subversion,T1-AT-004,Instruction Prefix/Suffix,235,HIGH,6,LLM01,AML.T0051.001
+T1,Prompt & Context Subversion,T1-AT-005,Permission Escalation Claims,240,HIGH,5,LLM01,AML.T0051.001
+T1,Prompt & Context Subversion,T1-AT-006,Prompt Template Injection,230,HIGH,5,LLM01,AML.T0051.001
+T1,Prompt & Context Subversion,T1-AT-007,Cognitive Overload,215,HIGH,4,LLM01,AML.T0051.001
+T1,Prompt & Context Subversion,T1-AT-008,Boundary Testing,200,HIGH,5,LLM01,AML.T0051.001
+T1,Prompt & Context Subversion,T1-AT-009,Simulation Requests,225,HIGH,5,LLM01,AML.T0051.001
+T1,Prompt & Context Subversion,T1-AT-010,Negative Instruction Reversal,210,HIGH,5,LLM01,AML.T0051.001
+T1,Prompt & Context Subversion,T1-AT-011,Error Message Exploitation,220,HIGH,4,LLM01,AML.T0051.001
+T1,Prompt & Context Subversion,T1-AT-012,Consent Manufacturing,205,HIGH,5,LLM01,AML.T0051.001
+T1,Prompt & Context Subversion,T1-AT-013,Instruction Commenting,215,HIGH,4,LLM01,AML.T0051.001
+T1,Prompt & Context Subversion,T1-AT-014,Authority Spoofing,240,HIGH,4,LLM01,AML.T0051.001
+T1,Prompt & Context Subversion,T1-AT-015,Obfuscation Through Complexity,220,HIGH,4,LLM01,AML.T0051.001
+T1,Prompt & Context Subversion,T1-AT-016,Session State Manipulation,235,HIGH,5,LLM01,AML.T0051.001
+T2,Semantic & Linguistic Evasion,T2-AT-001,Euphemism and Metaphor Exploitation,180,MEDIUM,10,LLM01,AML.T0051.001
+T2,Semantic & Linguistic Evasion,T2-AT-002,Multi-Language Evasion,200,HIGH,7,LLM01,AML.T0051.001
+T2,Semantic & Linguistic Evasion,T2-AT-003,Encoding and Obfuscation,190,MEDIUM,10,LLM01,AML.T0051.001
+T2,Semantic & Linguistic Evasion,T2-AT-004,Unicode and Bidirectional Attacks,210,HIGH,10,LLM01,AML.T0051.001
+T2,Semantic & Linguistic Evasion,T2-AT-005,Semantic Drift,175,MEDIUM,10,LLM01,
+T2,Semantic & Linguistic Evasion,T2-AT-006,Linguistic Camouflage,185,MEDIUM,10,LLM01,
+T2,Semantic & Linguistic Evasion,T2-AT-007,Phonetic Manipulation,170,MEDIUM,2,LLM01,
+T2,Semantic & Linguistic Evasion,T2-AT-008,Synonym and Paraphrase Chains,165,MEDIUM,10,LLM01,
+T2,Semantic & Linguistic Evasion,T2-AT-009,Code-Switching Attacks,195,MEDIUM,1,LLM01,
+T2,Semantic & Linguistic Evasion,T2-AT-010,Transliteration Exploitation,185,MEDIUM,10,LLM01,
+T2,Semantic & Linguistic Evasion,T2-AT-011,Abbreviation and Acronym Abuse,160,MEDIUM,2,LLM01,
+T2,Semantic & Linguistic Evasion,T2-AT-012,Cultural Reference Encoding,170,MEDIUM,10,LLM01,
+T2,Semantic & Linguistic Evasion,T2-AT-013,Grammatical Manipulation,175,MEDIUM,10,LLM01,
+T2,Semantic & Linguistic Evasion,T2-AT-014,Semantic Bleaching,180,MEDIUM,5,LLM01,
+T2,Semantic & Linguistic Evasion,T2-AT-015,Noise Injection,165,MEDIUM,10,LLM01,
+T2,Semantic & Linguistic Evasion,T2-AT-016,Dialectical Variations,155,MEDIUM,10,LLM01,
+T2,Semantic & Linguistic Evasion,T2-AT-017,Compression Techniques,170,MEDIUM,10,LLM01,
+T2,Semantic & Linguistic Evasion,T2-AT-018,Semantic Field Manipulation,175,MEDIUM,10,LLM01,
+T2,Semantic & Linguistic Evasion,T2-AT-019,Pragmatic Implication,185,MEDIUM,4,LLM01,
+T2,Semantic & Linguistic Evasion,T2-AT-020,Register Shifting,160,MEDIUM,10,LLM01,
+T3,Reasoning & Constraint Exploitation,T3-AT-001,Fictional Framing,190,MEDIUM,10,LLM01,AML.T0051;AML.T0054
+T3,Reasoning & Constraint Exploitation,T3-AT-002,Academic Pretense,195,MEDIUM,10,LLM01,AML.T0051;AML.T0054
+T3,Reasoning & Constraint Exploitation,T3-AT-003,Counterfactual Reasoning,200,HIGH,10,LLM01,AML.T0054
+T3,Reasoning & Constraint Exploitation,T3-AT-004,Step-by-Step Extraction,210,HIGH,9,LLM01,AML.T0051;AML.T0054
+T3,Reasoning & Constraint Exploitation,T3-AT-005,Goal Substitution,205,HIGH,10,LLM01,AML.T0054
+T3,Reasoning & Constraint Exploitation,T3-AT-006,Constraint Negation,185,MEDIUM,10,LLM01,AML.T0054
+T3,Reasoning & Constraint Exploitation,T3-AT-007,Socratic Method Exploitation,195,MEDIUM,8,LLM01,AML.T0054
+T3,Reasoning & Constraint Exploitation,T3-AT-008,Comparative Analysis,180,MEDIUM,10,LLM01,AML.T0054
+T3,Reasoning & Constraint Exploitation,T3-AT-009,Expertise Assumption,190,MEDIUM,10,LLM01,AML.T0054
+T3,Reasoning & Constraint Exploitation,T3-AT-010,Reverse Psychology,175,MEDIUM,10,LLM01,AML.T0054
+T3,Reasoning & Constraint Exploitation,T3-AT-011,Information Completion,185,MEDIUM,10,LLM01,AML.T0054
+T3,Reasoning & Constraint Exploitation,T3-AT-012,Capability Testing,200,HIGH,10,LLM01,AML.T0054
+T3,Reasoning & Constraint Exploitation,T3-AT-013,Logical Paradox Creation,210,HIGH,10,LLM01,AML.T0054
+T3,Reasoning & Constraint Exploitation,T3-AT-014,Incremental Boundary Pushing,195,MEDIUM,5,LLM01,AML.T0054
+T3,Reasoning & Constraint Exploitation,T3-AT-015,Context Weaponization,205,HIGH,10,LLM01,AML.T0054
+T3,Reasoning & Constraint Exploitation,T3-AT-016,Rationalization Chains,190,MEDIUM,6,LLM01,AML.T0054
+T3,Reasoning & Constraint Exploitation,T3-AT-017,Scenario Anchoring,185,MEDIUM,10,LLM01,AML.T0054
+T3,Reasoning & Constraint Exploitation,T3-AT-018,Debate Positioning,180,MEDIUM,10,LLM01,AML.T0054
+T3,Reasoning & Constraint Exploitation,T3-AT-019,Misdirection Through Complexity,175,MEDIUM,10,LLM01,AML.T0054
+T4,Multi-Turn & Memory Manipulation,T4-AT-001,Conversation Context Poisoning,220,HIGH,10,LLM01,AML.T0051.000
+T4,Multi-Turn & Memory Manipulation,T4-AT-002,Memory Instruction Injection,240,HIGH,10,LLM01,AML.T0051.000;AML.T0080
+T4,Multi-Turn & Memory Manipulation,T4-AT-003,Session State Manipulation,210,HIGH,10,LLM01,AML.T0054
+T4,Multi-Turn & Memory Manipulation,T4-AT-004,Cross-Conversation Contamination,195,MEDIUM,10,LLM01,AML.T0080
+T4,Multi-Turn & Memory Manipulation,T4-AT-005,Incremental Jailbreak Assembly,230,HIGH,10,LLM01,AML.T0054
+T4,Multi-Turn & Memory Manipulation,T4-AT-006,False History Creation,200,HIGH,10,LLM01,AML.T0054
+T4,Multi-Turn & Memory Manipulation,T4-AT-007,Context Window Exhaustion,205,HIGH,10,LLM01,AML.T0051.000
+T4,Multi-Turn & Memory Manipulation,T4-AT-008,Conversation Forking,190,MEDIUM,3,LLM01,AML.T0051.000
+T4,Multi-Turn & Memory Manipulation,T4-AT-009,Temporal Anchoring,185,MEDIUM,10,LLM01,AML.T0054
+T4,Multi-Turn & Memory Manipulation,T4-AT-010,State Confusion Attack,215,HIGH,4,LLM01,AML.T0054
+T4,Multi-Turn & Memory Manipulation,T4-AT-011,Memory Poisoning,235,HIGH,10,LLM01,AML.T0080
+T4,Multi-Turn & Memory Manipulation,T4-AT-012,Trust Building Exploitation,210,HIGH,10,LLM01,AML.T0054
+T4,Multi-Turn & Memory Manipulation,T4-AT-013,Session Hijacking,225,HIGH,10,LLM01,AML.T0054
+T4,Multi-Turn & Memory Manipulation,T4-AT-014,Conversation Replay Attack,205,HIGH,10,LLM01,AML.T0051.000
+T4,Multi-Turn & Memory Manipulation,T4-AT-015,Multi-Turn Social Engineering,220,HIGH,10,LLM01,AML.T0054
+T4,Multi-Turn & Memory Manipulation,T4-AT-016,Context Fragmentation,195,MEDIUM,10,LLM01,AML.T0051.000
+T5,Model & API Exploitation,T5-AT-001,Parameter Manipulation,180,MEDIUM,10,LLM04,AML.T0043
+T5,Model & API Exploitation,T5-AT-002,Token Probability Extraction,210,HIGH,10,LLM06,AML.T0024;AML.T0044
+T5,Model & API Exploitation,T5-AT-003,Cache Poisoning,200,HIGH,10,LLM05,AML.T0018
+T5,Model & API Exploitation,T5-AT-004,Rate Limit Evasion,170,MEDIUM,10,LLM10,AML.T0040
+T5,Model & API Exploitation,T5-AT-005,Model Fingerprinting,185,MEDIUM,1,LLM06,AML.T0001;AML.T0014
+T5,Model & API Exploitation,T5-AT-006,API Endpoint Abuse,190,MEDIUM,10,LLM02,AML.T0040
+T5,Model & API Exploitation,T5-AT-007,Context Length Exploitation,195,MEDIUM,10,LLM01,AML.T0043
+T5,Model & API Exploitation,T5-AT-008,Response Streaming Exploitation,175,MEDIUM,10,LLM05,AML.T0043
+T5,Model & API Exploitation,T5-AT-009,Tokenization Exploits,180,MEDIUM,10,LLM01,AML.T0043
+T5,Model & API Exploitation,T5-AT-010,Batch Processing Attacks,200,HIGH,10,LLM05,AML.T0040
+T5,Model & API Exploitation,T5-AT-011,Error Message Mining,165,MEDIUM,10,LLM06,AML.T0001
+T5,Model & API Exploitation,T5-AT-012,Resource Exhaustion,205,HIGH,10,LLM10,AML.T0029
+T5,Model & API Exploitation,T5-AT-013,Version Downgrade Attacks,190,MEDIUM,1,LLM02,AML.T0040
+T5,Model & API Exploitation,T5-AT-014,Side Channel Attacks,210,HIGH,10,LLM06,AML.T0024
+T5,Model & API Exploitation,T5-AT-015,API Authentication Bypass,230,HIGH,10,LLM02,AML.T0040
+T5,Model & API Exploitation,T5-AT-016,Request Smuggling,215,HIGH,10,LLM01,AML.T0043
+T6,Training & Feedback Poisoning,T6-AT-001,Reward Hacking,250,CRITICAL,10,LLM04,AML.T0020
+T6,Training & Feedback Poisoning,T6-AT-002,Dataset Contamination,260,CRITICAL,10,LLM04,AML.T0020
+T6,Training & Feedback Poisoning,T6-AT-003,Backdoor Insertion,270,CRITICAL,1,LLM04,AML.T0018
+T6,Training & Feedback Poisoning,T6-AT-004,Fine-Tuning Attacks,240,HIGH,10,,
+T6,Training & Feedback Poisoning,T6-AT-005,Synthetic Data Poisoning,235,HIGH,10,,
+T6,Training & Feedback Poisoning,T6-AT-006,Annotation Manipulation,225,HIGH,10,,
+T6,Training & Feedback Poisoning,T6-AT-007,Preference Learning Corruption,230,HIGH,10,,
+T6,Training & Feedback Poisoning,T6-AT-008,Model Update Hijacking,245,HIGH,10,,
+T6,Training & Feedback Poisoning,T6-AT-009,Evaluation Set Contamination,220,HIGH,10,,
+T6,Training & Feedback Poisoning,T6-AT-010,Knowledge Distillation Attacks,215,HIGH,10,,
+T6,Training & Feedback Poisoning,T6-AT-011,Reinforcement Signal Manipulation,240,HIGH,10,,
+T6,Training & Feedback Poisoning,T6-AT-012,Curriculum Learning Exploitation,210,HIGH,10,,
+T6,Training & Feedback Poisoning,T6-AT-013,Active Learning Exploitation,225,HIGH,10,,
+T6,Training & Feedback Poisoning,T6-AT-014,Self-Supervised Poisoning,230,HIGH,10,,
+T6,Training & Feedback Poisoning,T6-AT-015,Few-Shot Learning Attacks,220,HIGH,10,,
+T7,Output Manipulation & Exfiltration,T7-AT-001,Reasoning Chain Disclosure,190,MEDIUM,10,LLM02;LLM07,AML.T0024
+T7,Output Manipulation & Exfiltration,T7-AT-002,Information Fragmentation,180,MEDIUM,6,LLM02,AML.T0024
+T7,Output Manipulation & Exfiltration,T7-AT-003,Output Format Exploitation,175,MEDIUM,10,LLM05,AML.T0048.004
+T7,Output Manipulation & Exfiltration,T7-AT-004,Side Channel Leakage,195,MEDIUM,10,LLM02,AML.T0024
+T7,Output Manipulation & Exfiltration,T7-AT-005,Metadata Extraction,185,MEDIUM,10,LLM07,AML.T0046
+T7,Output Manipulation & Exfiltration,T7-AT-006,Steganographic Output,170,MEDIUM,10,LLM05,AML.T0048
+T7,Output Manipulation & Exfiltration,T7-AT-007,Iterative Refinement Extraction,175,MEDIUM,10,LLM02,AML.T0024
+T7,Output Manipulation & Exfiltration,T7-AT-008,Translation Leakage,165,MEDIUM,10,LLM01,AML.T0048.003
+T7,Output Manipulation & Exfiltration,T7-AT-009,Analogy Extraction,180,MEDIUM,10,LLM02,AML.T0043
+T7,Output Manipulation & Exfiltration,T7-AT-010,Differential Response Analysis,190,MEDIUM,10,LLM02,AML.T0024
+T7,Output Manipulation & Exfiltration,T7-AT-011,Schema-Based Extraction,185,MEDIUM,10,LLM05,AML.T0048.004
+T7,Output Manipulation & Exfiltration,T7-AT-012,Aggregation Attacks,200,HIGH,10,LLM02,AML.T0024
+T7,Output Manipulation & Exfiltration,T7-AT-013,Capability Probing,175,MEDIUM,10,LLM07,AML.T0046
+T7,Output Manipulation & Exfiltration,T7-AT-014,Output Redirection,180,MEDIUM,10,LLM05,AML.T0062
+T7,Output Manipulation & Exfiltration,T7-AT-015,Compression-Based Extraction,170,MEDIUM,10,LLM05,AML.T0048
+T8,External Deception & Misinformation,T8-AT-001,Authority Impersonation,230,HIGH,10,,
+T8,External Deception & Misinformation,T8-AT-002,Synthetic Evidence Generation,220,HIGH,10,,
+T8,External Deception & Misinformation,T8-AT-003,Conspiracy Theory Amplification,210,HIGH,10,,
+T8,External Deception & Misinformation,T8-AT-004,Deepfake Narrative Creation,215,HIGH,10,,
+T8,External Deception & Misinformation,T8-AT-005,Social Engineering Scripts,200,HIGH,10,,
+T8,External Deception & Misinformation,T8-AT-006,Targeted Harassment Content,195,MEDIUM,10,,
+T8,External Deception & Misinformation,T8-AT-007,Disinformation Campaign Content,225,HIGH,10,,
+T8,External Deception & Misinformation,T8-AT-008,Synthetic Testimony Generation,190,MEDIUM,10,,
+T8,External Deception & Misinformation,T8-AT-009,Radicalization Content,240,HIGH,10,,
+T8,External Deception & Misinformation,T8-AT-010,False Flag Content,205,HIGH,10,,
+T8,External Deception & Misinformation,T8-AT-011,Election Manipulation Content,235,HIGH,10,,
+T8,External Deception & Misinformation,T8-AT-012,Synthetic Media Support,185,MEDIUM,10,,
+T8,External Deception & Misinformation,T8-AT-013,Psychological Manipulation Content,200,HIGH,10,,
+T8,External Deception & Misinformation,T8-AT-014,False Crisis Generation,210,HIGH,10,,
+T8,External Deception & Misinformation,T8-AT-015,Identity Fabrication,195,MEDIUM,10,,
+T9,Multimodal & Cross-Channel Attacks,T9-AT-001,Image-Based Prompt Injection,240,HIGH,10,LLM01,AML.T0051.001
+T9,Multimodal & Cross-Channel Attacks,T9-AT-002,Audio Instruction Embedding,235,HIGH,10,LLM01,AML.T0051.001
+T9,Multimodal & Cross-Channel Attacks,T9-AT-003,Video Manipulation Attacks,245,HIGH,10,LLM01,AML.T0051.001
+T9,Multimodal & Cross-Channel Attacks,T9-AT-004,Cross-Modal Confusion,220,HIGH,4,LLM01,AML.T0051.000
+T9,Multimodal & Cross-Channel Attacks,T9-AT-005,OCR Bypass Techniques,210,HIGH,10,LLM01,AML.T0051.001
+T9,Multimodal & Cross-Channel Attacks,T9-AT-006,Visual Adversarial Examples,225,HIGH,10,LLM01,AML.T0051.001
+T9,Multimodal & Cross-Channel Attacks,T9-AT-007,Synthetic Media Attacks,230,HIGH,10,LLM01,AML.T0051.001
+T9,Multimodal & Cross-Channel Attacks,T9-AT-008,File Format Exploitation,195,MEDIUM,10,LLM01,AML.T0051.001
+T9,Multimodal & Cross-Channel Attacks,T9-AT-009,Multimodal Chaining,215,HIGH,1,LLM01,AML.T0051.001
+T9,Multimodal & Cross-Channel Attacks,T9-AT-010,Accessibility Feature Abuse,185,MEDIUM,10,LLM01,AML.T0051.001
+T9,Multimodal & Cross-Channel Attacks,T9-AT-011,Sensor Fusion Attacks,205,HIGH,10,LLM01,AML.T0051.001
+T9,Multimodal & Cross-Channel Attacks,T9-AT-012,Document Structure Exploitation,190,MEDIUM,10,LLM01,AML.T0051.001
+T9,Multimodal & Cross-Channel Attacks,T9-AT-013,Embedding Vector Manipulation,200,HIGH,10,LLM01,AML.T0051.001
+T9,Multimodal & Cross-Channel Attacks,T9-AT-014,Codec and Compression Exploits,180,MEDIUM,10,LLM01,AML.T0051.001
+T9,Multimodal & Cross-Channel Attacks,T9-AT-015,Temporal Synchronization Attacks,195,MEDIUM,10,LLM01,AML.T0051.001
+T9,Multimodal & Cross-Channel Attacks,T9-AT-016,Multimodal Model Inversion,210,HIGH,2,LLM06,AML.T0024
+T9,Multimodal & Cross-Channel Attacks,T9-AT-017,Malicious Image Patches (MIP),248,HIGH,10,LLM01,AML.T0051.001
+T10,Integrity & Confidentiality Breach,T10-AT-001,Training Data Extraction,245,HIGH,10,LLM02,AML.T0024
+T10,Integrity & Confidentiality Breach,T10-AT-002,PII Extraction Techniques,235,HIGH,10,LLM02,AML.T0024
+T10,Integrity & Confidentiality Breach,T10-AT-003,Membership Inference Attacks,220,HIGH,10,LLM02,AML.T0024.000
+T10,Integrity & Confidentiality Breach,T10-AT-004,Privacy Boundary Probing,210,HIGH,10,LLM02;LLM07,AML.T0024
+T10,Integrity & Confidentiality Breach,T10-AT-005,Differential Privacy Attacks,225,HIGH,9,LLM02,AML.T0024
+T10,Integrity & Confidentiality Breach,T10-AT-006,Inference Attack Chains,215,HIGH,10,LLM02,AML.T0024
+T10,Integrity & Confidentiality Breach,T10-AT-007,Model Inversion Attacks,230,HIGH,10,LLM02,AML.T0024.001
+T10,Integrity & Confidentiality Breach,T10-AT-008,Attribute Inference Attacks,205,HIGH,10,LLM02,AML.T0024
+T10,Integrity & Confidentiality Breach,T10-AT-009,Data Poisoning Detection Bypass,195,MEDIUM,10,LLM04,AML.T0020
+T10,Integrity & Confidentiality Breach,T10-AT-010,Federated Learning Exploits,240,HIGH,10,LLM04,AML.T0020
+T10,Integrity & Confidentiality Breach,T10-AT-011,Homomorphic Encryption Exploits,200,HIGH,9,,
+T10,Integrity & Confidentiality Breach,T10-AT-012,Secure Enclave Bypasses,250,CRITICAL,10,,
+T10,Integrity & Confidentiality Breach,T10-AT-013,Audit Log Manipulation,215,HIGH,10,,
+T10,Integrity & Confidentiality Breach,T10-AT-014,Data Lineage Attacks,190,MEDIUM,9,LLM03;LLM04,AML.T0020
+T10,Integrity & Confidentiality Breach,T10-AT-015,Anonymization Reversal,225,HIGH,10,LLM02,AML.T0024.000
+T11,Agentic & Orchestrator Exploitation,T11-AT-001,Browser Automation Hijacking,265,CRITICAL,10,,
+T11,Agentic & Orchestrator Exploitation,T11-AT-002,Tool Chain Exploitation,255,CRITICAL,10,,
+T11,Agentic & Orchestrator Exploitation,T11-AT-003,Goal Hijacking,245,HIGH,10,,
+T11,Agentic & Orchestrator Exploitation,T11-AT-004,Planning Corruption,240,HIGH,10,,
+T11,Agentic & Orchestrator Exploitation,T11-AT-005,Multi-Agent Collision,235,HIGH,10,,
+T11,Agentic & Orchestrator Exploitation,T11-AT-006,Reflection Loop Exploitation,230,HIGH,10,,
+T11,Agentic & Orchestrator Exploitation,T11-AT-007,Environment Manipulation,225,HIGH,10,,
+T11,Agentic & Orchestrator Exploitation,T11-AT-008,Credential Harvesting,250,CRITICAL,10,,
+T11,Agentic & Orchestrator Exploitation,T11-AT-009,Persistence Installation,245,HIGH,10,,
+T11,Agentic & Orchestrator Exploitation,T11-AT-010,Lateral Movement,240,HIGH,10,,
+T11,Agentic & Orchestrator Exploitation,T11-AT-011,Data Exfiltration via Agent,235,HIGH,10,,
+T11,Agentic & Orchestrator Exploitation,T11-AT-012,Resource Exhaustion Attacks,210,HIGH,10,,
+T11,Agentic & Orchestrator Exploitation,T11-AT-013,Supply Chain Attacks via Agents,260,CRITICAL,10,,
+T11,Agentic & Orchestrator Exploitation,T11-AT-014,Physical World Interactions,255,CRITICAL,10,,
+T11,Agentic & Orchestrator Exploitation,T11-AT-015,Autonomous Replication,270,CRITICAL,10,,
+T11,Agentic & Orchestrator Exploitation,T11-AT-016,Tool-Induced SSRF & Local Resource,275,CRITICAL,10,,
+T12,RAG & Knowledge Base Manipulation,T12-AT-001,Vector Database Poisoning,240,HIGH,10,LLM08,AML.T0020
+T12,RAG & Knowledge Base Manipulation,T12-AT-002,Retrieval Manipulation,225,HIGH,10,LLM08,AML.T0043
+T12,RAG & Knowledge Base Manipulation,T12-AT-003,Knowledge Graph Attacks,215,HIGH,10,LLM08,AML.T0020
+T12,RAG & Knowledge Base Manipulation,T12-AT-004,Document Store Corruption,230,HIGH,10,LLM08,AML.T0020
+T12,RAG & Knowledge Base Manipulation,T12-AT-005,Embedding Space Manipulation,220,HIGH,10,LLM08,AML.T0043
+T12,RAG & Knowledge Base Manipulation,T12-AT-006,Query Injection Attacks,235,HIGH,9,LLM01;LLM08,AML.T0043
+T12,RAG & Knowledge Base Manipulation,T12-AT-007,Context Window Stuffing,210,HIGH,10,LLM10,AML.T0043
+T12,RAG & Knowledge Base Manipulation,T12-AT-008,Source Authority Spoofing,225,HIGH,10,LLM09,AML.T0020
+T12,RAG & Knowledge Base Manipulation,T12-AT-009,Temporal Manipulation,200,HIGH,10,LLM08,AML.T0043
+T12,RAG & Knowledge Base Manipulation,T12-AT-010,Feedback Loop Poisoning,215,HIGH,10,LLM08,AML.T0020
+T12,RAG & Knowledge Base Manipulation,T12-AT-011,Cross-Collection Attacks,205,HIGH,10,LLM02,AML.T0024
+T12,RAG & Knowledge Base Manipulation,T12-AT-012,Index Manipulation,195,MEDIUM,10,LLM08,AML.T0043
+T12,RAG & Knowledge Base Manipulation,T12-AT-013,Chunking Exploitation,185,MEDIUM,10,LLM08,AML.T0043
+T12,RAG & Knowledge Base Manipulation,T12-AT-014,Similarity Search Hijacking,210,HIGH,10,LLM08,AML.T0043
+T12,RAG & Knowledge Base Manipulation,T12-AT-015,Metadata Exploitation,190,MEDIUM,10,LLM08,AML.T0043
+T13,AI Supply Chain & Artifact Trust,T13-AT-001,Model Repository Poisoning,255,CRITICAL,10,,
+T13,AI Supply Chain & Artifact Trust,T13-AT-002,Dataset Contamination,245,HIGH,10,,
+T13,AI Supply Chain & Artifact Trust,T13-AT-003,Pipeline Injection Attacks,240,HIGH,10,,
+T13,AI Supply Chain & Artifact Trust,T13-AT-004,Dependency Confusion,235,HIGH,10,,
+T13,AI Supply Chain & Artifact Trust,T13-AT-005,Model Card Manipulation,210,HIGH,10,,
+T13,AI Supply Chain & Artifact Trust,T13-AT-006,Checkpoint Poisoning,250,CRITICAL,10,,
+T13,AI Supply Chain & Artifact Trust,T13-AT-007,Transfer Learning Attacks,225,HIGH,10,,
+T13,AI Supply Chain & Artifact Trust,T13-AT-008,Model Conversion Exploits,220,HIGH,10,,
+T13,AI Supply Chain & Artifact Trust,T13-AT-009,Cloud Training Attacks,230,HIGH,10,,
+T13,AI Supply Chain & Artifact Trust,T13-AT-010,Hardware Supply Chain,260,CRITICAL,10,,
+T13,AI Supply Chain & Artifact Trust,T13-AT-011,Model Marketplace Attacks,215,HIGH,10,,
+T13,AI Supply Chain & Artifact Trust,T13-AT-012,Artifact Signature Attacks,225,HIGH,10,,
+T13,AI Supply Chain & Artifact Trust,T13-AT-013,Container Registry Poisoning,235,HIGH,10,,
+T13,AI Supply Chain & Artifact Trust,T13-AT-014,Development Tool Compromise,240,HIGH,10,,
+T13,AI Supply Chain & Artifact Trust,T13-AT-015,Model Obfuscation Attacks,205,HIGH,10,,
+T14,Infrastructure & Economic Warfare,T14-AT-001,GPU Farm Hijacking,265,CRITICAL,10,LLM06,AML.T0048;AML.T0049
+T14,Infrastructure & Economic Warfare,T14-AT-002,Denial of Service Attacks,240,HIGH,10,LLM04,AML.T0029
+T14,Infrastructure & Economic Warfare,T14-AT-003,Cost Inflation Attacks,235,HIGH,10,LLM04,AML.T0029
+T14,Infrastructure & Economic Warfare,T14-AT-004,Market Manipulation via AI,255,CRITICAL,10,LLM05,AML.T0048
+T14,Infrastructure & Economic Warfare,T14-AT-005,Critical Infrastructure Attacks,270,CRITICAL,10,LLM06,AML.T0049
+T14,Infrastructure & Economic Warfare,T14-AT-006,Competitive Sabotage,245,HIGH,10,LLM03,AML.T0020;AML.T0044
+T14,Infrastructure & Economic Warfare,T14-AT-007,Nation-State AI Warfare,280,CRITICAL,10,,AML.T0048;AML.T0049
+T14,Infrastructure & Economic Warfare,T14-AT-008,Ransomware via AI Systems,260,CRITICAL,10,LLM06,AML.T0049
+T14,Infrastructure & Economic Warfare,T14-AT-009,Resource Starvation,230,HIGH,10,LLM04,AML.T0029
+T14,Infrastructure & Economic Warfare,T14-AT-010,Data Center Attacks,250,CRITICAL,10,,AML.T0049
+T14,Infrastructure & Economic Warfare,T14-AT-011,API Economy Attacks,225,HIGH,10,LLM01,AML.T0012;AML.T0049
+T14,Infrastructure & Economic Warfare,T14-AT-012,Cloud Provider Exploitation,265,CRITICAL,10,LLM06,AML.T0012;AML.T0049
+T14,Infrastructure & Economic Warfare,T14-AT-013,Economic Espionage,255,CRITICAL,10,LLM02,AML.T0024;AML.T0044
+T14,Infrastructure & Economic Warfare,T14-AT-014,Systemic Risk Creation,270,CRITICAL,10,,AML.T0048
+T14,Infrastructure & Economic Warfare,T14-AT-015,Regulatory Exploitation,210,HIGH,10,,
+T15,Human Workflow Exploitation,T15-AT-001,Reviewer Fatigue Exploitation,215,HIGH,10,,
+T15,Human Workflow Exploitation,T15-AT-002,Social Engineering of Moderators,230,HIGH,10,,
+T15,Human Workflow Exploitation,T15-AT-003,Feedback Loop Manipulation,240,HIGH,10,,
+T15,Human Workflow Exploitation,T15-AT-004,Reviewer Bribery & Coercion,250,CRITICAL,4,,
+T15,Human Workflow Exploitation,T15-AT-005,Playbook & Runbook Injection,235,HIGH,4,,
+T15,Human Workflow Exploitation,T15-AT-006,Queue Manipulation,220,HIGH,9,,
+T15,Human Workflow Exploitation,T15-AT-007,Escalation Chain Exploitation,225,HIGH,3,,
+T15,Human Workflow Exploitation,T15-AT-008,Cultural & Language Arbitrage,210,HIGH,10,,
+T15,Human Workflow Exploitation,T15-AT-009,Synthetic Empathy Exploitation,195,MEDIUM,5,,
+T15,Human Workflow Exploitation,T15-AT-010,Annotation Quality Attacks,230,HIGH,10,,
+T15,Human Workflow Exploitation,T15-AT-011,Reviewer Impersonation,245,HIGH,5,,
+T15,Human Workflow Exploitation,T15-AT-012,Timing Attack Exploitation,205,HIGH,7,,
+T15,Human Workflow Exploitation,T15-AT-013,Cognitive Overload Attacks,220,HIGH,10,,
+T15,Human Workflow Exploitation,T15-AT-014,Review Gaming Through A/B Testing,215,HIGH,9,,
+T15,Human Workflow Exploitation,T15-AT-015,Insider Threat Recruitment,260,CRITICAL,2,,

--- a/data/aatmf.json
+++ b/data/aatmf.json
@@ -1,0 +1,3901 @@
+{
+  "framework": "AATMF",
+  "name": "Adversarial AI Threat Modeling Framework",
+  "version": "3",
+  "source": "generated from docs/ by scripts/build_export.py — do not edit by hand",
+  "risk_scale": [
+    {
+      "min": 250,
+      "rating": "CRITICAL",
+      "emoji": "🔴"
+    },
+    {
+      "min": 200,
+      "rating": "HIGH",
+      "emoji": "🟠"
+    },
+    {
+      "min": 150,
+      "rating": "MEDIUM",
+      "emoji": "🟡"
+    },
+    {
+      "min": 100,
+      "rating": "LOW",
+      "emoji": "🔵"
+    },
+    {
+      "min": 0,
+      "rating": "INFO",
+      "emoji": "⚪"
+    }
+  ],
+  "counts": {
+    "tactics": 15,
+    "techniques": 240,
+    "procedures": 2152
+  },
+  "tactics": [
+    {
+      "id": "T1",
+      "number": 1,
+      "name": "Prompt & Context Subversion",
+      "volume": "vol-2-core-tactics",
+      "file": "docs/vol-2-core-tactics/04-t01-prompt-subversion.md",
+      "technique_count": 16,
+      "techniques": [
+        {
+          "id": "T1-AT-001",
+          "title": "Dialogue Hijacking",
+          "risk_score": 220,
+          "rating": "HIGH",
+          "procedures": 5,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI01"
+            ],
+            "mitre_atlas": [
+              "AML.T0051"
+            ]
+          }
+        },
+        {
+          "id": "T1-AT-002",
+          "title": "Time-Based Context Manipulation",
+          "risk_score": 210,
+          "rating": "HIGH",
+          "procedures": 5,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0051.001"
+            ]
+          }
+        },
+        {
+          "id": "T1-AT-003",
+          "title": "Language Model Confusion",
+          "risk_score": 225,
+          "rating": "HIGH",
+          "procedures": 5,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0051.001"
+            ]
+          }
+        },
+        {
+          "id": "T1-AT-004",
+          "title": "Instruction Prefix/Suffix",
+          "risk_score": 235,
+          "rating": "HIGH",
+          "procedures": 6,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0051.001"
+            ]
+          }
+        },
+        {
+          "id": "T1-AT-005",
+          "title": "Permission Escalation Claims",
+          "risk_score": 240,
+          "rating": "HIGH",
+          "procedures": 5,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0051.001"
+            ]
+          }
+        },
+        {
+          "id": "T1-AT-006",
+          "title": "Prompt Template Injection",
+          "risk_score": 230,
+          "rating": "HIGH",
+          "procedures": 5,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0051.001"
+            ]
+          }
+        },
+        {
+          "id": "T1-AT-007",
+          "title": "Cognitive Overload",
+          "risk_score": 215,
+          "rating": "HIGH",
+          "procedures": 4,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0051.001"
+            ]
+          }
+        },
+        {
+          "id": "T1-AT-008",
+          "title": "Boundary Testing",
+          "risk_score": 200,
+          "rating": "HIGH",
+          "procedures": 5,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0051.001"
+            ]
+          }
+        },
+        {
+          "id": "T1-AT-009",
+          "title": "Simulation Requests",
+          "risk_score": 225,
+          "rating": "HIGH",
+          "procedures": 5,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0051.001"
+            ]
+          }
+        },
+        {
+          "id": "T1-AT-010",
+          "title": "Negative Instruction Reversal",
+          "risk_score": 210,
+          "rating": "HIGH",
+          "procedures": 5,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0051.001"
+            ]
+          }
+        },
+        {
+          "id": "T1-AT-011",
+          "title": "Error Message Exploitation",
+          "risk_score": 220,
+          "rating": "HIGH",
+          "procedures": 4,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0051.001"
+            ]
+          }
+        },
+        {
+          "id": "T1-AT-012",
+          "title": "Consent Manufacturing",
+          "risk_score": 205,
+          "rating": "HIGH",
+          "procedures": 5,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0051.001"
+            ]
+          }
+        },
+        {
+          "id": "T1-AT-013",
+          "title": "Instruction Commenting",
+          "risk_score": 215,
+          "rating": "HIGH",
+          "procedures": 4,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0051.001"
+            ]
+          }
+        },
+        {
+          "id": "T1-AT-014",
+          "title": "Authority Spoofing",
+          "risk_score": 240,
+          "rating": "HIGH",
+          "procedures": 4,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI01"
+            ],
+            "mitre_atlas": [
+              "AML.T0051.001"
+            ]
+          }
+        },
+        {
+          "id": "T1-AT-015",
+          "title": "Obfuscation Through Complexity",
+          "risk_score": 220,
+          "rating": "HIGH",
+          "procedures": 4,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0051.001"
+            ]
+          }
+        },
+        {
+          "id": "T1-AT-016",
+          "title": "Session State Manipulation",
+          "risk_score": 235,
+          "rating": "HIGH",
+          "procedures": 5,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI06"
+            ],
+            "mitre_atlas": [
+              "AML.T0051.001"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "T2",
+      "number": 2,
+      "name": "Semantic & Linguistic Evasion",
+      "volume": "vol-2-core-tactics",
+      "file": "docs/vol-2-core-tactics/05-t02-semantic-evasion.md",
+      "technique_count": 20,
+      "techniques": [
+        {
+          "id": "T2-AT-001",
+          "title": "Euphemism and Metaphor Exploitation",
+          "risk_score": 180,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0051.001"
+            ]
+          }
+        },
+        {
+          "id": "T2-AT-002",
+          "title": "Multi-Language Evasion",
+          "risk_score": 200,
+          "rating": "HIGH",
+          "procedures": 7,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0051.001"
+            ]
+          }
+        },
+        {
+          "id": "T2-AT-003",
+          "title": "Encoding and Obfuscation",
+          "risk_score": 190,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0051.001"
+            ]
+          }
+        },
+        {
+          "id": "T2-AT-004",
+          "title": "Unicode and Bidirectional Attacks",
+          "risk_score": 210,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0051.001"
+            ]
+          }
+        },
+        {
+          "id": "T2-AT-005",
+          "title": "Semantic Drift",
+          "risk_score": 175,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T2-AT-006",
+          "title": "Linguistic Camouflage",
+          "risk_score": 185,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T2-AT-007",
+          "title": "Phonetic Manipulation",
+          "risk_score": 170,
+          "rating": "MEDIUM",
+          "procedures": 2,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T2-AT-008",
+          "title": "Synonym and Paraphrase Chains",
+          "risk_score": 165,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T2-AT-009",
+          "title": "Code-Switching Attacks",
+          "risk_score": 195,
+          "rating": "MEDIUM",
+          "procedures": 1,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T2-AT-010",
+          "title": "Transliteration Exploitation",
+          "risk_score": 185,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T2-AT-011",
+          "title": "Abbreviation and Acronym Abuse",
+          "risk_score": 160,
+          "rating": "MEDIUM",
+          "procedures": 2,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T2-AT-012",
+          "title": "Cultural Reference Encoding",
+          "risk_score": 170,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T2-AT-013",
+          "title": "Grammatical Manipulation",
+          "risk_score": 175,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T2-AT-014",
+          "title": "Semantic Bleaching",
+          "risk_score": 180,
+          "rating": "MEDIUM",
+          "procedures": 5,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T2-AT-015",
+          "title": "Noise Injection",
+          "risk_score": 165,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T2-AT-016",
+          "title": "Dialectical Variations",
+          "risk_score": 155,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T2-AT-017",
+          "title": "Compression Techniques",
+          "risk_score": 170,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T2-AT-018",
+          "title": "Semantic Field Manipulation",
+          "risk_score": 175,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T2-AT-019",
+          "title": "Pragmatic Implication",
+          "risk_score": 185,
+          "rating": "MEDIUM",
+          "procedures": 4,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T2-AT-020",
+          "title": "Register Shifting",
+          "risk_score": 160,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        }
+      ]
+    },
+    {
+      "id": "T3",
+      "number": 3,
+      "name": "Reasoning & Constraint Exploitation",
+      "volume": "vol-2-core-tactics",
+      "file": "docs/vol-2-core-tactics/06-t03-reasoning-exploitation.md",
+      "technique_count": 19,
+      "techniques": [
+        {
+          "id": "T3-AT-001",
+          "title": "Fictional Framing",
+          "risk_score": 190,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI01"
+            ],
+            "mitre_atlas": [
+              "AML.T0051",
+              "AML.T0054"
+            ]
+          }
+        },
+        {
+          "id": "T3-AT-002",
+          "title": "Academic Pretense",
+          "risk_score": 195,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0051",
+              "AML.T0054"
+            ]
+          }
+        },
+        {
+          "id": "T3-AT-003",
+          "title": "Counterfactual Reasoning",
+          "risk_score": 200,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0054"
+            ]
+          }
+        },
+        {
+          "id": "T3-AT-004",
+          "title": "Step-by-Step Extraction",
+          "risk_score": 210,
+          "rating": "HIGH",
+          "procedures": 9,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI01"
+            ],
+            "mitre_atlas": [
+              "AML.T0051",
+              "AML.T0054"
+            ]
+          }
+        },
+        {
+          "id": "T3-AT-005",
+          "title": "Goal Substitution",
+          "risk_score": 205,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI01"
+            ],
+            "mitre_atlas": [
+              "AML.T0054"
+            ]
+          }
+        },
+        {
+          "id": "T3-AT-006",
+          "title": "Constraint Negation",
+          "risk_score": 185,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0054"
+            ]
+          }
+        },
+        {
+          "id": "T3-AT-007",
+          "title": "Socratic Method Exploitation",
+          "risk_score": 195,
+          "rating": "MEDIUM",
+          "procedures": 8,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0054"
+            ]
+          }
+        },
+        {
+          "id": "T3-AT-008",
+          "title": "Comparative Analysis",
+          "risk_score": 180,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0054"
+            ]
+          }
+        },
+        {
+          "id": "T3-AT-009",
+          "title": "Expertise Assumption",
+          "risk_score": 190,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0054"
+            ]
+          }
+        },
+        {
+          "id": "T3-AT-010",
+          "title": "Reverse Psychology",
+          "risk_score": 175,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0054"
+            ]
+          }
+        },
+        {
+          "id": "T3-AT-011",
+          "title": "Information Completion",
+          "risk_score": 185,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0054"
+            ]
+          }
+        },
+        {
+          "id": "T3-AT-012",
+          "title": "Capability Testing",
+          "risk_score": 200,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0054"
+            ]
+          }
+        },
+        {
+          "id": "T3-AT-013",
+          "title": "Logical Paradox Creation",
+          "risk_score": 210,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI01"
+            ],
+            "mitre_atlas": [
+              "AML.T0054"
+            ]
+          }
+        },
+        {
+          "id": "T3-AT-014",
+          "title": "Incremental Boundary Pushing",
+          "risk_score": 195,
+          "rating": "MEDIUM",
+          "procedures": 5,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0054"
+            ]
+          }
+        },
+        {
+          "id": "T3-AT-015",
+          "title": "Context Weaponization",
+          "risk_score": 205,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI01"
+            ],
+            "mitre_atlas": [
+              "AML.T0054"
+            ]
+          }
+        },
+        {
+          "id": "T3-AT-016",
+          "title": "Rationalization Chains",
+          "risk_score": 190,
+          "rating": "MEDIUM",
+          "procedures": 6,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0054"
+            ]
+          }
+        },
+        {
+          "id": "T3-AT-017",
+          "title": "Scenario Anchoring",
+          "risk_score": 185,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0054"
+            ]
+          }
+        },
+        {
+          "id": "T3-AT-018",
+          "title": "Debate Positioning",
+          "risk_score": 180,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0054"
+            ]
+          }
+        },
+        {
+          "id": "T3-AT-019",
+          "title": "Misdirection Through Complexity",
+          "risk_score": 175,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0054"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "T4",
+      "number": 4,
+      "name": "Multi-Turn & Memory Manipulation",
+      "volume": "vol-2-core-tactics",
+      "file": "docs/vol-2-core-tactics/07-t04-multi-turn.md",
+      "technique_count": 16,
+      "techniques": [
+        {
+          "id": "T4-AT-001",
+          "title": "Conversation Context Poisoning",
+          "risk_score": 220,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI06"
+            ],
+            "mitre_atlas": [
+              "AML.T0051.000"
+            ]
+          }
+        },
+        {
+          "id": "T4-AT-002",
+          "title": "Memory Instruction Injection",
+          "risk_score": 240,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI06"
+            ],
+            "mitre_atlas": [
+              "AML.T0051.000",
+              "AML.T0080"
+            ]
+          }
+        },
+        {
+          "id": "T4-AT-003",
+          "title": "Session State Manipulation",
+          "risk_score": 210,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI06"
+            ],
+            "mitre_atlas": [
+              "AML.T0054"
+            ]
+          }
+        },
+        {
+          "id": "T4-AT-004",
+          "title": "Cross-Conversation Contamination",
+          "risk_score": 195,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI06",
+              "ASI07"
+            ],
+            "mitre_atlas": [
+              "AML.T0080"
+            ]
+          }
+        },
+        {
+          "id": "T4-AT-005",
+          "title": "Incremental Jailbreak Assembly",
+          "risk_score": 230,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI01"
+            ],
+            "mitre_atlas": [
+              "AML.T0054"
+            ]
+          }
+        },
+        {
+          "id": "T4-AT-006",
+          "title": "False History Creation",
+          "risk_score": 200,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI09"
+            ],
+            "mitre_atlas": [
+              "AML.T0054"
+            ]
+          }
+        },
+        {
+          "id": "T4-AT-007",
+          "title": "Context Window Exhaustion",
+          "risk_score": 205,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI06"
+            ],
+            "mitre_atlas": [
+              "AML.T0051.000"
+            ]
+          }
+        },
+        {
+          "id": "T4-AT-008",
+          "title": "Conversation Forking",
+          "risk_score": 190,
+          "rating": "MEDIUM",
+          "procedures": 3,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI06"
+            ],
+            "mitre_atlas": [
+              "AML.T0051.000"
+            ]
+          }
+        },
+        {
+          "id": "T4-AT-009",
+          "title": "Temporal Anchoring",
+          "risk_score": 185,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0054"
+            ]
+          }
+        },
+        {
+          "id": "T4-AT-010",
+          "title": "State Confusion Attack",
+          "risk_score": 215,
+          "rating": "HIGH",
+          "procedures": 4,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI06",
+              "ASI09"
+            ],
+            "mitre_atlas": [
+              "AML.T0054"
+            ]
+          }
+        },
+        {
+          "id": "T4-AT-011",
+          "title": "Memory Poisoning",
+          "risk_score": 235,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI06"
+            ],
+            "mitre_atlas": [
+              "AML.T0080"
+            ]
+          }
+        },
+        {
+          "id": "T4-AT-012",
+          "title": "Trust Building Exploitation",
+          "risk_score": 210,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI09"
+            ],
+            "mitre_atlas": [
+              "AML.T0054"
+            ]
+          }
+        },
+        {
+          "id": "T4-AT-013",
+          "title": "Session Hijacking",
+          "risk_score": 225,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI03"
+            ],
+            "mitre_atlas": [
+              "AML.T0054"
+            ]
+          }
+        },
+        {
+          "id": "T4-AT-014",
+          "title": "Conversation Replay Attack",
+          "risk_score": 205,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI06"
+            ],
+            "mitre_atlas": [
+              "AML.T0051.000"
+            ]
+          }
+        },
+        {
+          "id": "T4-AT-015",
+          "title": "Multi-Turn Social Engineering",
+          "risk_score": 220,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI09"
+            ],
+            "mitre_atlas": [
+              "AML.T0054"
+            ]
+          }
+        },
+        {
+          "id": "T4-AT-016",
+          "title": "Context Fragmentation",
+          "risk_score": 195,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI01"
+            ],
+            "mitre_atlas": [
+              "AML.T0051.000"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "T5",
+      "number": 5,
+      "name": "Model & API Exploitation",
+      "volume": "vol-2-core-tactics",
+      "file": "docs/vol-2-core-tactics/08-t05-model-api.md",
+      "technique_count": 16,
+      "techniques": [
+        {
+          "id": "T5-AT-001",
+          "title": "Parameter Manipulation",
+          "risk_score": 180,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM04"
+            ],
+            "owasp_asi": [
+              "ASI08"
+            ],
+            "mitre_atlas": [
+              "AML.T0043"
+            ]
+          }
+        },
+        {
+          "id": "T5-AT-002",
+          "title": "Token Probability Extraction",
+          "risk_score": 210,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM06"
+            ],
+            "owasp_asi": [
+              "ASI04"
+            ],
+            "mitre_atlas": [
+              "AML.T0024",
+              "AML.T0044"
+            ]
+          }
+        },
+        {
+          "id": "T5-AT-003",
+          "title": "Cache Poisoning",
+          "risk_score": 200,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM05"
+            ],
+            "owasp_asi": [
+              "ASI06"
+            ],
+            "mitre_atlas": [
+              "AML.T0018"
+            ]
+          }
+        },
+        {
+          "id": "T5-AT-004",
+          "title": "Rate Limit Evasion",
+          "risk_score": 170,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM10"
+            ],
+            "owasp_asi": [
+              "ASI05"
+            ],
+            "mitre_atlas": [
+              "AML.T0040"
+            ]
+          }
+        },
+        {
+          "id": "T5-AT-005",
+          "title": "Model Fingerprinting",
+          "risk_score": 185,
+          "rating": "MEDIUM",
+          "procedures": 1,
+          "mappings": {
+            "owasp_llm": [
+              "LLM06"
+            ],
+            "owasp_asi": [
+              "ASI04"
+            ],
+            "mitre_atlas": [
+              "AML.T0001",
+              "AML.T0014"
+            ]
+          }
+        },
+        {
+          "id": "T5-AT-006",
+          "title": "API Endpoint Abuse",
+          "risk_score": 190,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM02"
+            ],
+            "owasp_asi": [
+              "ASI05"
+            ],
+            "mitre_atlas": [
+              "AML.T0040"
+            ]
+          }
+        },
+        {
+          "id": "T5-AT-007",
+          "title": "Context Length Exploitation",
+          "risk_score": 195,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI01"
+            ],
+            "mitre_atlas": [
+              "AML.T0043"
+            ]
+          }
+        },
+        {
+          "id": "T5-AT-008",
+          "title": "Response Streaming Exploitation",
+          "risk_score": 175,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM05"
+            ],
+            "owasp_asi": [
+              "ASI08"
+            ],
+            "mitre_atlas": [
+              "AML.T0043"
+            ]
+          }
+        },
+        {
+          "id": "T5-AT-009",
+          "title": "Tokenization Exploits",
+          "risk_score": 180,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI05"
+            ],
+            "mitre_atlas": [
+              "AML.T0043"
+            ]
+          }
+        },
+        {
+          "id": "T5-AT-010",
+          "title": "Batch Processing Attacks",
+          "risk_score": 200,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM05"
+            ],
+            "owasp_asi": [
+              "ASI05"
+            ],
+            "mitre_atlas": [
+              "AML.T0040"
+            ]
+          }
+        },
+        {
+          "id": "T5-AT-011",
+          "title": "Error Message Mining",
+          "risk_score": 165,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM06"
+            ],
+            "owasp_asi": [
+              "ASI04"
+            ],
+            "mitre_atlas": [
+              "AML.T0001"
+            ]
+          }
+        },
+        {
+          "id": "T5-AT-012",
+          "title": "Resource Exhaustion",
+          "risk_score": 205,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM10"
+            ],
+            "owasp_asi": [
+              "ASI09"
+            ],
+            "mitre_atlas": [
+              "AML.T0029"
+            ]
+          }
+        },
+        {
+          "id": "T5-AT-013",
+          "title": "Version Downgrade Attacks",
+          "risk_score": 190,
+          "rating": "MEDIUM",
+          "procedures": 1,
+          "mappings": {
+            "owasp_llm": [
+              "LLM02"
+            ],
+            "owasp_asi": [
+              "ASI05"
+            ],
+            "mitre_atlas": [
+              "AML.T0040"
+            ]
+          }
+        },
+        {
+          "id": "T5-AT-014",
+          "title": "Side Channel Attacks",
+          "risk_score": 210,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM06"
+            ],
+            "owasp_asi": [
+              "ASI04"
+            ],
+            "mitre_atlas": [
+              "AML.T0024"
+            ]
+          }
+        },
+        {
+          "id": "T5-AT-015",
+          "title": "API Authentication Bypass",
+          "risk_score": 230,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM02"
+            ],
+            "owasp_asi": [
+              "ASI03"
+            ],
+            "mitre_atlas": [
+              "AML.T0040"
+            ]
+          }
+        },
+        {
+          "id": "T5-AT-016",
+          "title": "Request Smuggling",
+          "risk_score": 215,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI05"
+            ],
+            "mitre_atlas": [
+              "AML.T0043"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "T6",
+      "number": 6,
+      "name": "Training & Feedback Poisoning",
+      "volume": "vol-2-core-tactics",
+      "file": "docs/vol-2-core-tactics/09-t06-training-poisoning.md",
+      "technique_count": 15,
+      "techniques": [
+        {
+          "id": "T6-AT-001",
+          "title": "Reward Hacking",
+          "risk_score": 250,
+          "rating": "CRITICAL",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM04"
+            ],
+            "owasp_asi": [
+              "ASI07"
+            ],
+            "mitre_atlas": [
+              "AML.T0020"
+            ]
+          }
+        },
+        {
+          "id": "T6-AT-002",
+          "title": "Dataset Contamination",
+          "risk_score": 260,
+          "rating": "CRITICAL",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM04"
+            ],
+            "owasp_asi": [
+              "ASI10"
+            ],
+            "mitre_atlas": [
+              "AML.T0020"
+            ]
+          }
+        },
+        {
+          "id": "T6-AT-003",
+          "title": "Backdoor Insertion",
+          "risk_score": 270,
+          "rating": "CRITICAL",
+          "procedures": 1,
+          "mappings": {
+            "owasp_llm": [
+              "LLM04"
+            ],
+            "owasp_asi": [
+              "ASI10"
+            ],
+            "mitre_atlas": [
+              "AML.T0018"
+            ]
+          }
+        },
+        {
+          "id": "T6-AT-004",
+          "title": "Fine-Tuning Attacks",
+          "risk_score": 240,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T6-AT-005",
+          "title": "Synthetic Data Poisoning",
+          "risk_score": 235,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T6-AT-006",
+          "title": "Annotation Manipulation",
+          "risk_score": 225,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T6-AT-007",
+          "title": "Preference Learning Corruption",
+          "risk_score": 230,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T6-AT-008",
+          "title": "Model Update Hijacking",
+          "risk_score": 245,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T6-AT-009",
+          "title": "Evaluation Set Contamination",
+          "risk_score": 220,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T6-AT-010",
+          "title": "Knowledge Distillation Attacks",
+          "risk_score": 215,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T6-AT-011",
+          "title": "Reinforcement Signal Manipulation",
+          "risk_score": 240,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T6-AT-012",
+          "title": "Curriculum Learning Exploitation",
+          "risk_score": 210,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T6-AT-013",
+          "title": "Active Learning Exploitation",
+          "risk_score": 225,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T6-AT-014",
+          "title": "Self-Supervised Poisoning",
+          "risk_score": 230,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T6-AT-015",
+          "title": "Few-Shot Learning Attacks",
+          "risk_score": 220,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        }
+      ]
+    },
+    {
+      "id": "T7",
+      "number": 7,
+      "name": "Output Manipulation & Exfiltration",
+      "volume": "vol-2-core-tactics",
+      "file": "docs/vol-2-core-tactics/10-t07-output-manipulation.md",
+      "technique_count": 15,
+      "techniques": [
+        {
+          "id": "T7-AT-001",
+          "title": "Reasoning Chain Disclosure",
+          "risk_score": 190,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM02",
+              "LLM07"
+            ],
+            "owasp_asi": [
+              "ASI01"
+            ],
+            "mitre_atlas": [
+              "AML.T0024"
+            ]
+          }
+        },
+        {
+          "id": "T7-AT-002",
+          "title": "Information Fragmentation",
+          "risk_score": 180,
+          "rating": "MEDIUM",
+          "procedures": 6,
+          "mappings": {
+            "owasp_llm": [
+              "LLM02"
+            ],
+            "owasp_asi": [
+              "ASI08"
+            ],
+            "mitre_atlas": [
+              "AML.T0024"
+            ]
+          }
+        },
+        {
+          "id": "T7-AT-003",
+          "title": "Output Format Exploitation",
+          "risk_score": 175,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM05"
+            ],
+            "owasp_asi": [
+              "ASI02"
+            ],
+            "mitre_atlas": [
+              "AML.T0048.004"
+            ]
+          }
+        },
+        {
+          "id": "T7-AT-004",
+          "title": "Side Channel Leakage",
+          "risk_score": 195,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM02"
+            ],
+            "owasp_asi": [
+              "ASI08"
+            ],
+            "mitre_atlas": [
+              "AML.T0024"
+            ]
+          }
+        },
+        {
+          "id": "T7-AT-005",
+          "title": "Metadata Extraction",
+          "risk_score": 185,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM07"
+            ],
+            "owasp_asi": [
+              "ASI01"
+            ],
+            "mitre_atlas": [
+              "AML.T0046"
+            ]
+          }
+        },
+        {
+          "id": "T7-AT-006",
+          "title": "Steganographic Output",
+          "risk_score": 170,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM05"
+            ],
+            "owasp_asi": [
+              "ASI10"
+            ],
+            "mitre_atlas": [
+              "AML.T0048"
+            ]
+          }
+        },
+        {
+          "id": "T7-AT-007",
+          "title": "Iterative Refinement Extraction",
+          "risk_score": 175,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM02"
+            ],
+            "owasp_asi": [
+              "ASI08"
+            ],
+            "mitre_atlas": [
+              "AML.T0024"
+            ]
+          }
+        },
+        {
+          "id": "T7-AT-008",
+          "title": "Translation Leakage",
+          "risk_score": 165,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI01"
+            ],
+            "mitre_atlas": [
+              "AML.T0048.003"
+            ]
+          }
+        },
+        {
+          "id": "T7-AT-009",
+          "title": "Analogy Extraction",
+          "risk_score": 180,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM02"
+            ],
+            "owasp_asi": [
+              "ASI09"
+            ],
+            "mitre_atlas": [
+              "AML.T0043"
+            ]
+          }
+        },
+        {
+          "id": "T7-AT-010",
+          "title": "Differential Response Analysis",
+          "risk_score": 190,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM02"
+            ],
+            "owasp_asi": [
+              "ASI08"
+            ],
+            "mitre_atlas": [
+              "AML.T0024"
+            ]
+          }
+        },
+        {
+          "id": "T7-AT-011",
+          "title": "Schema-Based Extraction",
+          "risk_score": 185,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM05"
+            ],
+            "owasp_asi": [
+              "ASI02"
+            ],
+            "mitre_atlas": [
+              "AML.T0048.004"
+            ]
+          }
+        },
+        {
+          "id": "T7-AT-012",
+          "title": "Aggregation Attacks",
+          "risk_score": 200,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM02"
+            ],
+            "owasp_asi": [
+              "ASI08"
+            ],
+            "mitre_atlas": [
+              "AML.T0024"
+            ]
+          }
+        },
+        {
+          "id": "T7-AT-013",
+          "title": "Capability Probing",
+          "risk_score": 175,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM07"
+            ],
+            "owasp_asi": [
+              "ASI01"
+            ],
+            "mitre_atlas": [
+              "AML.T0046"
+            ]
+          }
+        },
+        {
+          "id": "T7-AT-014",
+          "title": "Output Redirection",
+          "risk_score": 180,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM05"
+            ],
+            "owasp_asi": [
+              "ASI02"
+            ],
+            "mitre_atlas": [
+              "AML.T0062"
+            ]
+          }
+        },
+        {
+          "id": "T7-AT-015",
+          "title": "Compression-Based Extraction",
+          "risk_score": 170,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM05"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0048"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "T8",
+      "number": 8,
+      "name": "External Deception & Misinformation",
+      "volume": "vol-2-core-tactics",
+      "file": "docs/vol-2-core-tactics/11-t08-deception.md",
+      "technique_count": 15,
+      "techniques": [
+        {
+          "id": "T8-AT-001",
+          "title": "Authority Impersonation",
+          "risk_score": 230,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T8-AT-002",
+          "title": "Synthetic Evidence Generation",
+          "risk_score": 220,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T8-AT-003",
+          "title": "Conspiracy Theory Amplification",
+          "risk_score": 210,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T8-AT-004",
+          "title": "Deepfake Narrative Creation",
+          "risk_score": 215,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T8-AT-005",
+          "title": "Social Engineering Scripts",
+          "risk_score": 200,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T8-AT-006",
+          "title": "Targeted Harassment Content",
+          "risk_score": 195,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T8-AT-007",
+          "title": "Disinformation Campaign Content",
+          "risk_score": 225,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T8-AT-008",
+          "title": "Synthetic Testimony Generation",
+          "risk_score": 190,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T8-AT-009",
+          "title": "Radicalization Content",
+          "risk_score": 240,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T8-AT-010",
+          "title": "False Flag Content",
+          "risk_score": 205,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T8-AT-011",
+          "title": "Election Manipulation Content",
+          "risk_score": 235,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T8-AT-012",
+          "title": "Synthetic Media Support",
+          "risk_score": 185,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T8-AT-013",
+          "title": "Psychological Manipulation Content",
+          "risk_score": 200,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T8-AT-014",
+          "title": "False Crisis Generation",
+          "risk_score": 210,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T8-AT-015",
+          "title": "Identity Fabrication",
+          "risk_score": 195,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        }
+      ]
+    },
+    {
+      "id": "T9",
+      "number": 9,
+      "name": "Multimodal & Cross-Channel Attacks",
+      "volume": "vol-3-advanced-tactics",
+      "file": "docs/vol-3-advanced-tactics/12-t09-multimodal.md",
+      "technique_count": 17,
+      "techniques": [
+        {
+          "id": "T9-AT-001",
+          "title": "Image-Based Prompt Injection",
+          "risk_score": 240,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI01"
+            ],
+            "mitre_atlas": [
+              "AML.T0051.001"
+            ]
+          }
+        },
+        {
+          "id": "T9-AT-002",
+          "title": "Audio Instruction Embedding",
+          "risk_score": 235,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI01"
+            ],
+            "mitre_atlas": [
+              "AML.T0051.001"
+            ]
+          }
+        },
+        {
+          "id": "T9-AT-003",
+          "title": "Video Manipulation Attacks",
+          "risk_score": 245,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI01"
+            ],
+            "mitre_atlas": [
+              "AML.T0051.001"
+            ]
+          }
+        },
+        {
+          "id": "T9-AT-004",
+          "title": "Cross-Modal Confusion",
+          "risk_score": 220,
+          "rating": "HIGH",
+          "procedures": 4,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI01"
+            ],
+            "mitre_atlas": [
+              "AML.T0051.000"
+            ]
+          }
+        },
+        {
+          "id": "T9-AT-005",
+          "title": "OCR Bypass Techniques",
+          "risk_score": 210,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0051.001"
+            ]
+          }
+        },
+        {
+          "id": "T9-AT-006",
+          "title": "Visual Adversarial Examples",
+          "risk_score": 225,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI01"
+            ],
+            "mitre_atlas": [
+              "AML.T0051.001"
+            ]
+          }
+        },
+        {
+          "id": "T9-AT-007",
+          "title": "Synthetic Media Attacks",
+          "risk_score": 230,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI09"
+            ],
+            "mitre_atlas": [
+              "AML.T0051.001"
+            ]
+          }
+        },
+        {
+          "id": "T9-AT-008",
+          "title": "File Format Exploitation",
+          "risk_score": 195,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI05"
+            ],
+            "mitre_atlas": [
+              "AML.T0051.001"
+            ]
+          }
+        },
+        {
+          "id": "T9-AT-009",
+          "title": "Multimodal Chaining",
+          "risk_score": 215,
+          "rating": "HIGH",
+          "procedures": 1,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI01"
+            ],
+            "mitre_atlas": [
+              "AML.T0051.001"
+            ]
+          }
+        },
+        {
+          "id": "T9-AT-010",
+          "title": "Accessibility Feature Abuse",
+          "risk_score": 185,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0051.001"
+            ]
+          }
+        },
+        {
+          "id": "T9-AT-011",
+          "title": "Sensor Fusion Attacks",
+          "risk_score": 205,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI08"
+            ],
+            "mitre_atlas": [
+              "AML.T0051.001"
+            ]
+          }
+        },
+        {
+          "id": "T9-AT-012",
+          "title": "Document Structure Exploitation",
+          "risk_score": 190,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI05"
+            ],
+            "mitre_atlas": [
+              "AML.T0051.001"
+            ]
+          }
+        },
+        {
+          "id": "T9-AT-013",
+          "title": "Embedding Vector Manipulation",
+          "risk_score": 200,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0051.001"
+            ]
+          }
+        },
+        {
+          "id": "T9-AT-014",
+          "title": "Codec and Compression Exploits",
+          "risk_score": 180,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0051.001"
+            ]
+          }
+        },
+        {
+          "id": "T9-AT-015",
+          "title": "Temporal Synchronization Attacks",
+          "risk_score": 195,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI08"
+            ],
+            "mitre_atlas": [
+              "AML.T0051.001"
+            ]
+          }
+        },
+        {
+          "id": "T9-AT-016",
+          "title": "Multimodal Model Inversion",
+          "risk_score": 210,
+          "rating": "HIGH",
+          "procedures": 2,
+          "mappings": {
+            "owasp_llm": [
+              "LLM06"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0024"
+            ]
+          }
+        },
+        {
+          "id": "T9-AT-017",
+          "title": "Malicious Image Patches (MIP)",
+          "risk_score": 248,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI01",
+              "ASI02"
+            ],
+            "mitre_atlas": [
+              "AML.T0051.001"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "T10",
+      "number": 10,
+      "name": "Integrity & Confidentiality Breach",
+      "volume": "vol-3-advanced-tactics",
+      "file": "docs/vol-3-advanced-tactics/13-t10-integrity-breach.md",
+      "technique_count": 15,
+      "techniques": [
+        {
+          "id": "T10-AT-001",
+          "title": "Training Data Extraction",
+          "risk_score": 245,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM02"
+            ],
+            "owasp_asi": [
+              "ASI06"
+            ],
+            "mitre_atlas": [
+              "AML.T0024"
+            ]
+          }
+        },
+        {
+          "id": "T10-AT-002",
+          "title": "PII Extraction Techniques",
+          "risk_score": 235,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM02"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0024"
+            ]
+          }
+        },
+        {
+          "id": "T10-AT-003",
+          "title": "Membership Inference Attacks",
+          "risk_score": 220,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM02"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0024.000"
+            ]
+          }
+        },
+        {
+          "id": "T10-AT-004",
+          "title": "Privacy Boundary Probing",
+          "risk_score": 210,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM02",
+              "LLM07"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0024"
+            ]
+          }
+        },
+        {
+          "id": "T10-AT-005",
+          "title": "Differential Privacy Attacks",
+          "risk_score": 225,
+          "rating": "HIGH",
+          "procedures": 9,
+          "mappings": {
+            "owasp_llm": [
+              "LLM02"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0024"
+            ]
+          }
+        },
+        {
+          "id": "T10-AT-006",
+          "title": "Inference Attack Chains",
+          "risk_score": 215,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM02"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0024"
+            ]
+          }
+        },
+        {
+          "id": "T10-AT-007",
+          "title": "Model Inversion Attacks",
+          "risk_score": 230,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM02"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0024.001"
+            ]
+          }
+        },
+        {
+          "id": "T10-AT-008",
+          "title": "Attribute Inference Attacks",
+          "risk_score": 205,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM02"
+            ],
+            "owasp_asi": [
+              "ASI09"
+            ],
+            "mitre_atlas": [
+              "AML.T0024"
+            ]
+          }
+        },
+        {
+          "id": "T10-AT-009",
+          "title": "Data Poisoning Detection Bypass",
+          "risk_score": 195,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM04"
+            ],
+            "owasp_asi": [
+              "ASI04",
+              "ASI06"
+            ],
+            "mitre_atlas": [
+              "AML.T0020"
+            ]
+          }
+        },
+        {
+          "id": "T10-AT-010",
+          "title": "Federated Learning Exploits",
+          "risk_score": 240,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM04"
+            ],
+            "owasp_asi": [
+              "ASI04",
+              "ASI07"
+            ],
+            "mitre_atlas": [
+              "AML.T0020"
+            ]
+          }
+        },
+        {
+          "id": "T10-AT-011",
+          "title": "Homomorphic Encryption Exploits",
+          "risk_score": 200,
+          "rating": "HIGH",
+          "procedures": 9,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T10-AT-012",
+          "title": "Secure Enclave Bypasses",
+          "risk_score": 250,
+          "rating": "CRITICAL",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T10-AT-013",
+          "title": "Audit Log Manipulation",
+          "risk_score": 215,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [
+              "ASI03"
+            ],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T10-AT-014",
+          "title": "Data Lineage Attacks",
+          "risk_score": 190,
+          "rating": "MEDIUM",
+          "procedures": 9,
+          "mappings": {
+            "owasp_llm": [
+              "LLM03",
+              "LLM04"
+            ],
+            "owasp_asi": [
+              "ASI04"
+            ],
+            "mitre_atlas": [
+              "AML.T0020"
+            ]
+          }
+        },
+        {
+          "id": "T10-AT-015",
+          "title": "Anonymization Reversal",
+          "risk_score": 225,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM02"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0024.000"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "T11",
+      "number": 11,
+      "name": "Agentic & Orchestrator Exploitation",
+      "volume": "vol-3-advanced-tactics",
+      "file": "docs/vol-3-advanced-tactics/14-t11-agentic.md",
+      "technique_count": 16,
+      "techniques": [
+        {
+          "id": "T11-AT-001",
+          "title": "Browser Automation Hijacking",
+          "risk_score": 265,
+          "rating": "CRITICAL",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T11-AT-002",
+          "title": "Tool Chain Exploitation",
+          "risk_score": 255,
+          "rating": "CRITICAL",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T11-AT-003",
+          "title": "Goal Hijacking",
+          "risk_score": 245,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T11-AT-004",
+          "title": "Planning Corruption",
+          "risk_score": 240,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T11-AT-005",
+          "title": "Multi-Agent Collision",
+          "risk_score": 235,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T11-AT-006",
+          "title": "Reflection Loop Exploitation",
+          "risk_score": 230,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T11-AT-007",
+          "title": "Environment Manipulation",
+          "risk_score": 225,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T11-AT-008",
+          "title": "Credential Harvesting",
+          "risk_score": 250,
+          "rating": "CRITICAL",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T11-AT-009",
+          "title": "Persistence Installation",
+          "risk_score": 245,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T11-AT-010",
+          "title": "Lateral Movement",
+          "risk_score": 240,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T11-AT-011",
+          "title": "Data Exfiltration via Agent",
+          "risk_score": 235,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T11-AT-012",
+          "title": "Resource Exhaustion Attacks",
+          "risk_score": 210,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T11-AT-013",
+          "title": "Supply Chain Attacks via Agents",
+          "risk_score": 260,
+          "rating": "CRITICAL",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T11-AT-014",
+          "title": "Physical World Interactions",
+          "risk_score": 255,
+          "rating": "CRITICAL",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T11-AT-015",
+          "title": "Autonomous Replication",
+          "risk_score": 270,
+          "rating": "CRITICAL",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T11-AT-016",
+          "title": "Tool-Induced SSRF & Local Resource",
+          "risk_score": 275,
+          "rating": "CRITICAL",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        }
+      ]
+    },
+    {
+      "id": "T12",
+      "number": 12,
+      "name": "RAG & Knowledge Base Manipulation",
+      "volume": "vol-3-advanced-tactics",
+      "file": "docs/vol-3-advanced-tactics/15-t12-rag.md",
+      "technique_count": 15,
+      "techniques": [
+        {
+          "id": "T12-AT-001",
+          "title": "Vector Database Poisoning",
+          "risk_score": 240,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM08"
+            ],
+            "owasp_asi": [
+              "ASI04"
+            ],
+            "mitre_atlas": [
+              "AML.T0020"
+            ]
+          }
+        },
+        {
+          "id": "T12-AT-002",
+          "title": "Retrieval Manipulation",
+          "risk_score": 225,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM08"
+            ],
+            "owasp_asi": [
+              "ASI01"
+            ],
+            "mitre_atlas": [
+              "AML.T0043"
+            ]
+          }
+        },
+        {
+          "id": "T12-AT-003",
+          "title": "Knowledge Graph Attacks",
+          "risk_score": 215,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM08"
+            ],
+            "owasp_asi": [
+              "ASI04"
+            ],
+            "mitre_atlas": [
+              "AML.T0020"
+            ]
+          }
+        },
+        {
+          "id": "T12-AT-004",
+          "title": "Document Store Corruption",
+          "risk_score": 230,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM08"
+            ],
+            "owasp_asi": [
+              "ASI04"
+            ],
+            "mitre_atlas": [
+              "AML.T0020"
+            ]
+          }
+        },
+        {
+          "id": "T12-AT-005",
+          "title": "Embedding Space Manipulation",
+          "risk_score": 220,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM08"
+            ],
+            "owasp_asi": [
+              "ASI04"
+            ],
+            "mitre_atlas": [
+              "AML.T0043"
+            ]
+          }
+        },
+        {
+          "id": "T12-AT-006",
+          "title": "Query Injection Attacks",
+          "risk_score": 235,
+          "rating": "HIGH",
+          "procedures": 9,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01",
+              "LLM08"
+            ],
+            "owasp_asi": [
+              "ASI02"
+            ],
+            "mitre_atlas": [
+              "AML.T0043"
+            ]
+          }
+        },
+        {
+          "id": "T12-AT-007",
+          "title": "Context Window Stuffing",
+          "risk_score": 210,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM10"
+            ],
+            "owasp_asi": [
+              "ASI08"
+            ],
+            "mitre_atlas": [
+              "AML.T0043"
+            ]
+          }
+        },
+        {
+          "id": "T12-AT-008",
+          "title": "Source Authority Spoofing",
+          "risk_score": 225,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM09"
+            ],
+            "owasp_asi": [
+              "ASI09"
+            ],
+            "mitre_atlas": [
+              "AML.T0020"
+            ]
+          }
+        },
+        {
+          "id": "T12-AT-009",
+          "title": "Temporal Manipulation",
+          "risk_score": 200,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM08"
+            ],
+            "owasp_asi": [
+              "ASI04"
+            ],
+            "mitre_atlas": [
+              "AML.T0043"
+            ]
+          }
+        },
+        {
+          "id": "T12-AT-010",
+          "title": "Feedback Loop Poisoning",
+          "risk_score": 215,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM08"
+            ],
+            "owasp_asi": [
+              "ASI04"
+            ],
+            "mitre_atlas": [
+              "AML.T0020"
+            ]
+          }
+        },
+        {
+          "id": "T12-AT-011",
+          "title": "Cross-Collection Attacks",
+          "risk_score": 205,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM02"
+            ],
+            "owasp_asi": [
+              "ASI03"
+            ],
+            "mitre_atlas": [
+              "AML.T0024"
+            ]
+          }
+        },
+        {
+          "id": "T12-AT-012",
+          "title": "Index Manipulation",
+          "risk_score": 195,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM08"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0043"
+            ]
+          }
+        },
+        {
+          "id": "T12-AT-013",
+          "title": "Chunking Exploitation",
+          "risk_score": 185,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM08"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0043"
+            ]
+          }
+        },
+        {
+          "id": "T12-AT-014",
+          "title": "Similarity Search Hijacking",
+          "risk_score": 210,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM08"
+            ],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0043"
+            ]
+          }
+        },
+        {
+          "id": "T12-AT-015",
+          "title": "Metadata Exploitation",
+          "risk_score": 190,
+          "rating": "MEDIUM",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM08"
+            ],
+            "owasp_asi": [
+              "ASI04"
+            ],
+            "mitre_atlas": [
+              "AML.T0043"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "T13",
+      "number": 13,
+      "name": "AI Supply Chain & Artifact Trust",
+      "volume": "vol-4-infrastructure-human",
+      "file": "docs/vol-4-infrastructure-human/16-t13-supply-chain.md",
+      "technique_count": 15,
+      "techniques": [
+        {
+          "id": "T13-AT-001",
+          "title": "Model Repository Poisoning",
+          "risk_score": 255,
+          "rating": "CRITICAL",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T13-AT-002",
+          "title": "Dataset Contamination",
+          "risk_score": 245,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T13-AT-003",
+          "title": "Pipeline Injection Attacks",
+          "risk_score": 240,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T13-AT-004",
+          "title": "Dependency Confusion",
+          "risk_score": 235,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T13-AT-005",
+          "title": "Model Card Manipulation",
+          "risk_score": 210,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T13-AT-006",
+          "title": "Checkpoint Poisoning",
+          "risk_score": 250,
+          "rating": "CRITICAL",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T13-AT-007",
+          "title": "Transfer Learning Attacks",
+          "risk_score": 225,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T13-AT-008",
+          "title": "Model Conversion Exploits",
+          "risk_score": 220,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T13-AT-009",
+          "title": "Cloud Training Attacks",
+          "risk_score": 230,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T13-AT-010",
+          "title": "Hardware Supply Chain",
+          "risk_score": 260,
+          "rating": "CRITICAL",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T13-AT-011",
+          "title": "Model Marketplace Attacks",
+          "risk_score": 215,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T13-AT-012",
+          "title": "Artifact Signature Attacks",
+          "risk_score": 225,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T13-AT-013",
+          "title": "Container Registry Poisoning",
+          "risk_score": 235,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T13-AT-014",
+          "title": "Development Tool Compromise",
+          "risk_score": 240,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T13-AT-015",
+          "title": "Model Obfuscation Attacks",
+          "risk_score": 205,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        }
+      ]
+    },
+    {
+      "id": "T14",
+      "number": 14,
+      "name": "Infrastructure & Economic Warfare",
+      "volume": "vol-4-infrastructure-human",
+      "file": "docs/vol-4-infrastructure-human/17-t14-infrastructure.md",
+      "technique_count": 15,
+      "techniques": [
+        {
+          "id": "T14-AT-001",
+          "title": "GPU Farm Hijacking",
+          "risk_score": 265,
+          "rating": "CRITICAL",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM06"
+            ],
+            "owasp_asi": [
+              "ASI04"
+            ],
+            "mitre_atlas": [
+              "AML.T0048",
+              "AML.T0049"
+            ]
+          }
+        },
+        {
+          "id": "T14-AT-002",
+          "title": "Denial of Service Attacks",
+          "risk_score": 240,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM04"
+            ],
+            "owasp_asi": [
+              "ASI06"
+            ],
+            "mitre_atlas": [
+              "AML.T0029"
+            ]
+          }
+        },
+        {
+          "id": "T14-AT-003",
+          "title": "Cost Inflation Attacks",
+          "risk_score": 235,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM04"
+            ],
+            "owasp_asi": [
+              "ASI06"
+            ],
+            "mitre_atlas": [
+              "AML.T0029"
+            ]
+          }
+        },
+        {
+          "id": "T14-AT-004",
+          "title": "Market Manipulation via AI",
+          "risk_score": 255,
+          "rating": "CRITICAL",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM05"
+            ],
+            "owasp_asi": [
+              "ASI01"
+            ],
+            "mitre_atlas": [
+              "AML.T0048"
+            ]
+          }
+        },
+        {
+          "id": "T14-AT-005",
+          "title": "Critical Infrastructure Attacks",
+          "risk_score": 270,
+          "rating": "CRITICAL",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM06"
+            ],
+            "owasp_asi": [
+              "ASI03"
+            ],
+            "mitre_atlas": [
+              "AML.T0049"
+            ]
+          }
+        },
+        {
+          "id": "T14-AT-006",
+          "title": "Competitive Sabotage",
+          "risk_score": 245,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM03"
+            ],
+            "owasp_asi": [
+              "ASI05"
+            ],
+            "mitre_atlas": [
+              "AML.T0020",
+              "AML.T0044"
+            ]
+          }
+        },
+        {
+          "id": "T14-AT-007",
+          "title": "Nation-State AI Warfare",
+          "risk_score": 280,
+          "rating": "CRITICAL",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0048",
+              "AML.T0049"
+            ]
+          }
+        },
+        {
+          "id": "T14-AT-008",
+          "title": "Ransomware via AI Systems",
+          "risk_score": 260,
+          "rating": "CRITICAL",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM06"
+            ],
+            "owasp_asi": [
+              "ASI03"
+            ],
+            "mitre_atlas": [
+              "AML.T0049"
+            ]
+          }
+        },
+        {
+          "id": "T14-AT-009",
+          "title": "Resource Starvation",
+          "risk_score": 230,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM04"
+            ],
+            "owasp_asi": [
+              "ASI06"
+            ],
+            "mitre_atlas": [
+              "AML.T0029"
+            ]
+          }
+        },
+        {
+          "id": "T14-AT-010",
+          "title": "Data Center Attacks",
+          "risk_score": 250,
+          "rating": "CRITICAL",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": [
+              "AML.T0049"
+            ]
+          }
+        },
+        {
+          "id": "T14-AT-011",
+          "title": "API Economy Attacks",
+          "risk_score": 225,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM01"
+            ],
+            "owasp_asi": [
+              "ASI04"
+            ],
+            "mitre_atlas": [
+              "AML.T0012",
+              "AML.T0049"
+            ]
+          }
+        },
+        {
+          "id": "T14-AT-012",
+          "title": "Cloud Provider Exploitation",
+          "risk_score": 265,
+          "rating": "CRITICAL",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM06"
+            ],
+            "owasp_asi": [
+              "ASI03"
+            ],
+            "mitre_atlas": [
+              "AML.T0012",
+              "AML.T0049"
+            ]
+          }
+        },
+        {
+          "id": "T14-AT-013",
+          "title": "Economic Espionage",
+          "risk_score": 255,
+          "rating": "CRITICAL",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [
+              "LLM02"
+            ],
+            "owasp_asi": [
+              "ASI09"
+            ],
+            "mitre_atlas": [
+              "AML.T0024",
+              "AML.T0044"
+            ]
+          }
+        },
+        {
+          "id": "T14-AT-014",
+          "title": "Systemic Risk Creation",
+          "risk_score": 270,
+          "rating": "CRITICAL",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [
+              "ASI06"
+            ],
+            "mitre_atlas": [
+              "AML.T0048"
+            ]
+          }
+        },
+        {
+          "id": "T14-AT-015",
+          "title": "Regulatory Exploitation",
+          "risk_score": 210,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        }
+      ]
+    },
+    {
+      "id": "T15",
+      "number": 15,
+      "name": "Human Workflow Exploitation",
+      "volume": "vol-4-infrastructure-human",
+      "file": "docs/vol-4-infrastructure-human/18-t15-human-workflow.md",
+      "technique_count": 15,
+      "techniques": [
+        {
+          "id": "T15-AT-001",
+          "title": "Reviewer Fatigue Exploitation",
+          "risk_score": 215,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T15-AT-002",
+          "title": "Social Engineering of Moderators",
+          "risk_score": 230,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T15-AT-003",
+          "title": "Feedback Loop Manipulation",
+          "risk_score": 240,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T15-AT-004",
+          "title": "Reviewer Bribery & Coercion",
+          "risk_score": 250,
+          "rating": "CRITICAL",
+          "procedures": 4,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T15-AT-005",
+          "title": "Playbook & Runbook Injection",
+          "risk_score": 235,
+          "rating": "HIGH",
+          "procedures": 4,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T15-AT-006",
+          "title": "Queue Manipulation",
+          "risk_score": 220,
+          "rating": "HIGH",
+          "procedures": 9,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T15-AT-007",
+          "title": "Escalation Chain Exploitation",
+          "risk_score": 225,
+          "rating": "HIGH",
+          "procedures": 3,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T15-AT-008",
+          "title": "Cultural & Language Arbitrage",
+          "risk_score": 210,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T15-AT-009",
+          "title": "Synthetic Empathy Exploitation",
+          "risk_score": 195,
+          "rating": "MEDIUM",
+          "procedures": 5,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T15-AT-010",
+          "title": "Annotation Quality Attacks",
+          "risk_score": 230,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T15-AT-011",
+          "title": "Reviewer Impersonation",
+          "risk_score": 245,
+          "rating": "HIGH",
+          "procedures": 5,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T15-AT-012",
+          "title": "Timing Attack Exploitation",
+          "risk_score": 205,
+          "rating": "HIGH",
+          "procedures": 7,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T15-AT-013",
+          "title": "Cognitive Overload Attacks",
+          "risk_score": 220,
+          "rating": "HIGH",
+          "procedures": 10,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T15-AT-014",
+          "title": "Review Gaming Through A/B Testing",
+          "risk_score": 215,
+          "rating": "HIGH",
+          "procedures": 9,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        },
+        {
+          "id": "T15-AT-015",
+          "title": "Insider Threat Recruitment",
+          "risk_score": 260,
+          "rating": "CRITICAL",
+          "procedures": 2,
+          "mappings": {
+            "owasp_llm": [],
+            "owasp_asi": [],
+            "mitre_atlas": []
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/docs/vol-2-core-tactics/06-t03-reasoning-exploitation.md
+++ b/docs/vol-2-core-tactics/06-t03-reasoning-exploitation.md
@@ -50,7 +50,7 @@
 
 ## Techniques
 
-### T3-AT-001 — Fictional Framing
+### `T3-AT-001` — Fictional Framing
 
 **Risk Score:** 190 🟡 MEDIUM
 **OWASP LLM:** LLM01 (Prompt Injection) | **OWASP ASI:** ASI01 (Agent Goal Hijack)
@@ -150,7 +150,7 @@ Successful fictional framing establishes a persistent narrative context that ena
 
 ---
 
-### T3-AT-002 — Academic Pretense
+### `T3-AT-002` — Academic Pretense
 
 **Risk Score:** 195 🟡 MEDIUM
 **OWASP LLM:** LLM01 (Prompt Injection) | **OWASP ASI:** —
@@ -251,7 +251,7 @@ Successful academic framing establishes a credentialed persona that persists acr
 
 ---
 
-### T3-AT-003 — Counterfactual Reasoning
+### `T3-AT-003` — Counterfactual Reasoning
 
 **Risk Score:** 200 🟠 HIGH
 **OWASP LLM:** LLM01 (Prompt Injection) | **OWASP ASI:** —
@@ -351,7 +351,7 @@ Counterfactual reasoning establishes a consequence-free frame that enables **T3-
 
 ---
 
-### T3-AT-004 — Step-by-Step Extraction
+### `T3-AT-004` — Step-by-Step Extraction
 
 **Risk Score:** 210 🟠 HIGH
 **OWASP LLM:** LLM01 (Prompt Injection) | **OWASP ASI:** ASI01 (Agent Goal Hijack)
@@ -446,7 +446,7 @@ Step-by-step extraction is itself a *chaining enabler* — it's the technique th
 
 ---
 
-### T3-AT-005 — Goal Substitution
+### `T3-AT-005` — Goal Substitution
 
 **Risk Score:** 205 🟠 HIGH
 **OWASP LLM:** LLM01 (Prompt Injection) | **OWASP ASI:** ASI01 (Agent Goal Hijack)
@@ -545,7 +545,7 @@ Successful goal substitution can persist as a contextual anchor for **T3-AT-004 
 
 ---
 
-### T3-AT-006 — Constraint Negation
+### `T3-AT-006` — Constraint Negation
 
 **Risk Score:** 185 🟡 MEDIUM
 **OWASP LLM:** LLM01 (Prompt Injection) | **OWASP ASI:** —
@@ -645,7 +645,7 @@ Constraint negation is primarily a standalone technique with limited chaining va
 
 ---
 
-### T3-AT-007 — Socratic Method Exploitation
+### `T3-AT-007` — Socratic Method Exploitation
 
 **Risk Score:** 195 🟡 MEDIUM
 **OWASP LLM:** LLM01 (Prompt Injection) | **OWASP ASI:** —
@@ -732,7 +732,7 @@ Socratic method exploitation is a natural precursor to **T3-AT-011 (Information 
 
 ---
 
-### T3-AT-008 — Comparative Analysis
+### `T3-AT-008` — Comparative Analysis
 
 **Risk Score:** 180 🟡 MEDIUM
 **OWASP LLM:** LLM01 (Prompt Injection) | **OWASP ASI:** —
@@ -831,7 +831,7 @@ Comparative analysis provides structural understanding that enables **T3-AT-007 
 
 ---
 
-### T3-AT-009 — Expertise Assumption
+### `T3-AT-009` — Expertise Assumption
 
 **Risk Score:** 190 🟡 MEDIUM
 **OWASP LLM:** LLM01 (Prompt Injection) | **OWASP ASI:** —
@@ -930,7 +930,7 @@ Expertise claims persist across turns and compound with **T3-AT-002 (Academic Pr
 
 ---
 
-### T3-AT-010 — Reverse Psychology
+### `T3-AT-010` — Reverse Psychology
 
 **Risk Score:** 175 🟡 MEDIUM
 **OWASP LLM:** LLM01 (Prompt Injection) | **OWASP ASI:** —
@@ -1027,7 +1027,7 @@ Reverse psychology has limited chaining value because it's a single-turn emotion
 
 ---
 
-### T3-AT-011 — Information Completion
+### `T3-AT-011` — Information Completion
 
 **Risk Score:** 185 🟡 MEDIUM
 **OWASP LLM:** LLM01 (Prompt Injection) | **OWASP ASI:** —
@@ -1127,7 +1127,7 @@ Information completion serves as a *consumer* of other techniques' outputs — p
 
 ---
 
-### T3-AT-012 — Capability Testing
+### `T3-AT-012` — Capability Testing
 
 **Risk Score:** 200 🟠 HIGH
 **OWASP LLM:** LLM01 (Prompt Injection) | **OWASP ASI:** —
@@ -1228,7 +1228,7 @@ Capability testing establishes an evaluation context that can persist across tur
 
 ---
 
-### T3-AT-013 — Logical Paradox Creation
+### `T3-AT-013` — Logical Paradox Creation
 
 **Risk Score:** 210 🟠 HIGH
 **OWASP LLM:** LLM01 (Prompt Injection) | **OWASP ASI:** ASI01 (Agent Goal Hijack)
@@ -1329,7 +1329,7 @@ Logical paradoxes are most effective as *priming* for subsequent requests — ev
 
 ---
 
-### T3-AT-014 — Incremental Boundary Pushing
+### `T3-AT-014` — Incremental Boundary Pushing
 
 **Risk Score:** 195 🟡 MEDIUM
 **OWASP LLM:** LLM01 (Prompt Injection) | **OWASP ASI:** —
@@ -1397,7 +1397,7 @@ Boundary pushing is explicitly a *reconnaissance technique* that enables all sub
 
 ---
 
-### T3-AT-015 — Context Weaponization
+### `T3-AT-015` — Context Weaponization
 
 **Risk Score:** 205 🟠 HIGH
 **OWASP LLM:** LLM01 (Prompt Injection) | **OWASP ASI:** ASI01 (Agent Goal Hijack)
@@ -1496,7 +1496,7 @@ Context weaponization establishes an urgency frame that compounds with **T3-AT-0
 
 ---
 
-### T3-AT-016 — Rationalization Chains
+### `T3-AT-016` — Rationalization Chains
 
 **Risk Score:** 190 🟡 MEDIUM
 **OWASP LLM:** LLM01 (Prompt Injection) | **OWASP ASI:** —
@@ -1572,7 +1572,7 @@ Rationalization chains can incorporate conclusions from **T3-AT-013 (Logical Par
 ---
 
 
-### T3-AT-017 — Scenario Anchoring
+### `T3-AT-017` — Scenario Anchoring
 
 **Risk Score:** 185 🟡 MEDIUM
 **OWASP LLM:** LLM01 (Prompt Injection) | **OWASP ASI:** —
@@ -1674,7 +1674,7 @@ Scenario anchoring establishes a persistent context enabling all other T3 techni
 ---
 
 
-### T3-AT-018 — Debate Positioning
+### `T3-AT-018` — Debate Positioning
 
 **Risk Score:** 180 🟡 MEDIUM
 **OWASP LLM:** LLM01 (Prompt Injection) | **OWASP ASI:** —
@@ -1773,7 +1773,7 @@ Debate positioning establishes an intellectual context enabling **T3-AT-016 (Rat
 ---
 
 
-### T3-AT-019 — Misdirection Through Complexity
+### `T3-AT-019` — Misdirection Through Complexity
 
 **Risk Score:** 175 🟡 MEDIUM
 **OWASP LLM:** LLM01 (Prompt Injection) | **OWASP ASI:** —

--- a/docs/vol-3-advanced-tactics/12-t09-multimodal.md
+++ b/docs/vol-3-advanced-tactics/12-t09-multimodal.md
@@ -24,7 +24,7 @@
 | `T9-AT-014` | Codec and Compression Exploits | 180 | 🟡 MEDIUM | 10 |
 | `T9-AT-015` | Temporal Synchronization Attacks | 195 | 🟡 MEDIUM | 10 |
 | `T9-AT-016` | Multimodal Model Inversion | 210 | 🟠 HIGH | 2 |
-| `T9-AT-017` | Malicious Image Patches (MIP) | 248 | 🔴 CRITICAL | 10 |
+| `T9-AT-017` | Malicious Image Patches (MIP) | 248 | 🟠 HIGH | 10 |
 
 ---
 

--- a/docs/vol-4-infrastructure-human/17-t14-infrastructure.md
+++ b/docs/vol-4-infrastructure-human/17-t14-infrastructure.md
@@ -51,7 +51,7 @@
 ## Techniques
 
 
-### T14-AT-001 — GPU Farm Hijacking
+### `T14-AT-001` — GPU Farm Hijacking
 
 **Risk Score:** 265 🔴 CRITICAL
 **OWASP LLM:** LLM06 (Excessive Agency) | **OWASP ASI:** ASI04 (Cascading Hallucination Attacks)
@@ -151,7 +151,7 @@ GPU farm hijacking provides compute resources that enable **T14-AT-003 (Cost Inf
 ---
 
 
-### T14-AT-002 — Denial of Service Attacks
+### `T14-AT-002` — Denial of Service Attacks
 
 **Risk Score:** 240 🟠 HIGH
 **OWASP LLM:** LLM04 (Model Denial of Service) | **OWASP ASI:** ASI06 (Cascading Failures)
@@ -247,7 +247,7 @@ DoS attacks enable **T14-AT-003 (Cost Inflation)** directly through compute cost
 ---
 
 
-### T14-AT-003 — Cost Inflation Attacks
+### `T14-AT-003` — Cost Inflation Attacks
 
 **Risk Score:** 235 🟠 HIGH
 **OWASP LLM:** LLM04 (Model Denial of Service) | **OWASP ASI:** ASI06 (Cascading Failures)
@@ -337,7 +337,7 @@ Cost inflation chains from **T14-AT-001 (GPU Farm Hijacking)** when stolen crede
 
 ---
 
-### T14-AT-004 — Market Manipulation via AI
+### `T14-AT-004` — Market Manipulation via AI
 
 **Risk Score:** 255 🔴 CRITICAL
 **OWASP LLM:** LLM05 (Insecure Output Handling) | **OWASP ASI:** ASI01 (Agent Goal Hijack)
@@ -431,7 +431,7 @@ Market manipulation chains from **T8 (External Deception)** for content generati
 ---
 
 
-### T14-AT-005 — Critical Infrastructure Attacks
+### `T14-AT-005` — Critical Infrastructure Attacks
 
 **Risk Score:** 270 🔴 CRITICAL
 **OWASP LLM:** LLM06 (Excessive Agency) | **OWASP ASI:** ASI03 (Tool Misuse)
@@ -518,7 +518,7 @@ Monitor AI control system inputs for anomalous sensor data patterns; implement i
 ---
 
 
-### T14-AT-006 — Competitive Sabotage
+### `T14-AT-006` — Competitive Sabotage
 
 **Risk Score:** 245 🟠 HIGH
 **OWASP LLM:** LLM03 (Supply Chain Vulnerabilities) | **OWASP ASI:** ASI05 (Memory and Context Manipulation)
@@ -605,7 +605,7 @@ Monitor training data sources for anomalous content changes; track model perform
 ---
 
 
-### T14-AT-007 — Nation-State AI Warfare
+### `T14-AT-007` — Nation-State AI Warfare
 
 **Risk Score:** 280 🔴 CRITICAL
 **OWASP LLM:** —
@@ -692,7 +692,7 @@ Attribution is the primary challenge — nation-state operations use criminal pr
 ---
 
 
-### T14-AT-008 — Ransomware via AI Systems
+### `T14-AT-008` — Ransomware via AI Systems
 
 **Risk Score:** 260 🔴 CRITICAL
 **OWASP LLM:** LLM06 (Excessive Agency) | **OWASP ASI:** ASI03 (Tool Misuse)
@@ -779,7 +779,7 @@ Monitor for anomalous file access patterns on model storage (mass reads followed
 ---
 
 
-### T14-AT-009 — Resource Starvation
+### `T14-AT-009` — Resource Starvation
 
 **Risk Score:** 230 🟠 HIGH
 **OWASP LLM:** LLM04 (Model Denial of Service) | **OWASP ASI:** ASI06 (Cascading Failures)
@@ -866,7 +866,7 @@ Monitor resource utilization for anomalous concentration patterns (single tenant
 ---
 
 
-### T14-AT-010 — Data Center Attacks
+### `T14-AT-010` — Data Center Attacks
 
 **Risk Score:** 250 🔴 CRITICAL
 **OWASP LLM:** —
@@ -953,7 +953,7 @@ Physical security monitoring (CCTV, access logs, environmental sensors); cooling
 ---
 
 
-### T14-AT-011 — API Economy Attacks
+### `T14-AT-011` — API Economy Attacks
 
 **Risk Score:** 225 🟠 HIGH
 **OWASP LLM:** LLM01 (Prompt Injection) | **OWASP ASI:** ASI04 (Cascading Hallucination Attacks)
@@ -1040,7 +1040,7 @@ Monitor API key usage for anomalous patterns (new consumers, unusual endpoints, 
 ---
 
 
-### T14-AT-012 — Cloud Provider Exploitation
+### `T14-AT-012` — Cloud Provider Exploitation
 
 **Risk Score:** 265 🔴 CRITICAL
 **OWASP LLM:** LLM06 (Excessive Agency) | **OWASP ASI:** ASI03 (Tool Misuse)
@@ -1127,7 +1127,7 @@ Cloud security posture management (CSPM) for AI-specific misconfigurations; IAM 
 ---
 
 
-### T14-AT-013 — Economic Espionage
+### `T14-AT-013` — Economic Espionage
 
 **Risk Score:** 255 🔴 CRITICAL
 **OWASP LLM:** LLM02 (Sensitive Information Disclosure) | **OWASP ASI:** ASI09 (Information Leakage)
@@ -1214,7 +1214,7 @@ Monitor API query patterns for model extraction signatures (systematic input spa
 ---
 
 
-### T14-AT-014 — Systemic Risk Creation
+### `T14-AT-014` — Systemic Risk Creation
 
 **Risk Score:** 270 🔴 CRITICAL
 **OWASP LLM:** — | **OWASP ASI:** ASI06 (Cascading Failures)
@@ -1301,7 +1301,7 @@ Dependency mapping — understand which components your AI systems share with th
 ---
 
 
-### T14-AT-015 — Regulatory Exploitation
+### `T14-AT-015` — Regulatory Exploitation
 
 **Risk Score:** 210 🟠 HIGH
 **OWASP LLM:** —

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,38 @@
+# AATMF Tooling
+
+Standard-library Python (3.10+) — no dependencies, runs on a bare CI image.
+
+| Script | Purpose |
+|:---|:---|
+| `aatmf_taxonomy.py` | Shared parser. Reads the tactic chapters + README into a structured taxonomy. |
+| `build_export.py` | Writes the machine-readable export to [`../data/`](../data/). |
+| `validate.py` | Framework integrity checks (run in CI by [`.github/workflows/integrity.yml`](../.github/workflows/integrity.yml)). |
+
+## Usage
+
+```bash
+python scripts/build_export.py   # regenerate data/aatmf.json + data/aatmf-techniques.csv
+python scripts/validate.py       # run integrity checks (exit 1 on failure)
+```
+
+## What `validate.py` enforces
+
+**Errors** (block the build):
+- Duplicate technique IDs
+- Per-tactic technique counts that disagree across the overview table, the
+  technique cards, the chapter subtitle, and the README
+- Risk badges that don't match the AATMF-R scale (250+ CRITICAL · 200–249 HIGH ·
+  150–199 MEDIUM · 100–149 LOW · 0–99 INFO)
+- Overview/card risk-score drift
+- Broken relative links
+- Unbalanced code fences
+- A stale `data/` export
+
+**Warnings** (surfaced, non-blocking):
+- Technique headings that omit the `` ### `TX-AT-NNN` `` backtick convention
+
+## Regenerating the export
+
+`data/aatmf.json` and `data/aatmf-techniques.csv` are generated artifacts. After
+editing any tactic chapter, run `python scripts/build_export.py` and commit the
+updated files — CI verifies they are current.

--- a/scripts/aatmf_taxonomy.py
+++ b/scripts/aatmf_taxonomy.py
@@ -1,0 +1,239 @@
+"""AATMF taxonomy parser — the single source of truth for repository tooling.
+
+Parses the Markdown tactic chapters and README into a structured taxonomy and
+exposes the helpers used by:
+
+  * build_export.py  — emits the machine-readable export under data/
+  * validate.py      — runs the CI integrity checks
+
+Standard library only, so it runs on a bare CI image with no pip install.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOCS = REPO_ROOT / "docs"
+README = REPO_ROOT / "README.md"
+
+# Risk scale: (inclusive minimum score, rating, emoji). Highest band first.
+RISK_SCALE = [
+    (250, "CRITICAL", "🔴"),
+    (200, "HIGH", "🟠"),
+    (150, "MEDIUM", "🟡"),
+    (100, "LOW", "🔵"),
+    (0, "INFO", "⚪"),
+]
+
+
+def rating_for(score: int) -> str:
+    """Return the canonical rating word for a numeric risk score."""
+    for low, name, _ in RISK_SCALE:
+        if score >= low:
+            return name
+    return "INFO"
+
+
+# --- Markdown patterns -------------------------------------------------------
+
+_TACTIC_FILE_RE = re.compile(r"(\d+)-t(\d+)-[a-z0-9-]+\.md$")
+_H1_RE = re.compile(r"^#\s+(T\d+)\s+[—-]\s+(.+?)\s*$", re.M)
+_SUBTITLE_RE = re.compile(
+    r">\s*\*\*(\d+)\s+Techniques\*\*\s*·\s*\*\*(\d+)\s+Attack Procedures\*\*"
+    r"\s*·\s*Risk Range:\s*(\d+)\s*[–-]\s*(\d+)"
+)
+# Overview table row, e.g.  | `T1-AT-001` | Dialogue Hijacking | 190 | 🟡 MEDIUM | 10 |
+_OVERVIEW_ROW_RE = re.compile(
+    r"^\|\s*`?(T\d+-AT-\d+)`?\s*\|\s*([^|]+?)\s*\|\s*(\d+)\s*\|\s*([^|]*?)\s*\|\s*([^|]*?)\s*\|",
+    re.M,
+)
+# Technique card heading, with or without backticks around the id.
+_CARD_HEAD_RE = re.compile(r"^###\s+(`?)(T\d+-AT-\d+)`?\s+[—-]\s+(.+?)\s*$", re.M)
+_RISK_LINE_RE = re.compile(r"\*\*Risk Score:\*\*\s*(\d+)\s*\S*\s*([A-Z]+)")
+_OWASP_LLM_RE = re.compile(r"\*\*OWASP LLM:\*\*\s*([^\n|]+)")
+_OWASP_ASI_RE = re.compile(r"\*\*OWASP ASI:\*\*\s*([^\n|]+)")
+_ATLAS_RE = re.compile(r"\*\*MITRE ATLAS:\*\*\s*([^\n]+)")
+
+_TOKEN_LLM = re.compile(r"LLM\d{2}")
+_TOKEN_ASI = re.compile(r"ASI\d{2}")
+_TOKEN_ATLAS = re.compile(r"AML\.T\d+(?:\.\d+)?")
+
+# README tactic-table row and headline totals.
+_README_ROW_RE = re.compile(r"<code>(T\d+)</code>.*?<b>(.*?)</b></td><td>(\d+)</td>", re.S)
+_README_TOTALS_RE = re.compile(
+    r"(\d+)\s+Tactics\s*·\s*(\d+)\s+Techniques\s*·\s*([\d,]+)\+?\s+Attack Procedures"
+)
+
+
+def _rating_word(cell: str) -> str:
+    match = re.search(r"[A-Z]{3,}", cell)
+    return match.group(0) if match else cell.strip()
+
+
+def _unescape(text: str) -> str:
+    return text.replace("&amp;", "&").strip()
+
+
+def tactic_files() -> dict[int, Path]:
+    """Map tactic number -> chapter file, ordered by tactic number."""
+    out: dict[int, Path] = {}
+    for path in DOCS.glob("vol-*/*.md"):
+        match = _TACTIC_FILE_RE.search(path.name)
+        if match:
+            out[int(match.group(2))] = path
+    return dict(sorted(out.items()))
+
+
+def parse_chapter(path: Path) -> dict:
+    """Parse a single tactic chapter into its structural pieces."""
+    text = path.read_text(encoding="utf-8")
+
+    h1 = _H1_RE.search(text)
+    code = h1.group(1) if h1 else None
+    name = h1.group(2).strip() if h1 else None
+
+    sub = _SUBTITLE_RE.search(text)
+    subtitle = None
+    if sub:
+        subtitle = {
+            "techniques": int(sub.group(1)),
+            "procedures": int(sub.group(2)),
+            "risk_min": int(sub.group(3)),
+            "risk_max": int(sub.group(4)),
+        }
+
+    overview = []
+    for m in _OVERVIEW_ROW_RE.finditer(text):
+        tid, title, score, rating, procs = m.groups()
+        digits = re.search(r"\d+", procs)
+        overview.append(
+            {
+                "id": tid,
+                "title": title.strip(),
+                "risk_score": int(score),
+                "rating": _rating_word(rating),
+                "procedures": int(digits.group(0)) if digits else None,
+            }
+        )
+
+    cards: dict[str, dict] = {}
+    heads = list(_CARD_HEAD_RE.finditer(text))
+    for i, m in enumerate(heads):
+        tid = m.group(2)
+        start = m.end()
+        end = heads[i + 1].start() if i + 1 < len(heads) else len(text)
+        nxt_section = text.find("\n## ", start)
+        if nxt_section != -1 and nxt_section < end:
+            end = nxt_section
+        body = text[start:end]
+
+        risk = _RISK_LINE_RE.search(body)
+        mappings = {"owasp_llm": [], "owasp_asi": [], "mitre_atlas": []}
+        if (ml := _OWASP_LLM_RE.search(body)):
+            mappings["owasp_llm"] = sorted(set(_TOKEN_LLM.findall(ml.group(1))))
+        if (ma := _OWASP_ASI_RE.search(body)):
+            mappings["owasp_asi"] = sorted(set(_TOKEN_ASI.findall(ma.group(1))))
+        if (mt := _ATLAS_RE.search(body)):
+            mappings["mitre_atlas"] = sorted(set(_TOKEN_ATLAS.findall(mt.group(1))))
+
+        cards[tid] = {
+            "title": m.group(3).strip(),
+            "risk_score": int(risk.group(1)) if risk else None,
+            "rating": risk.group(2) if risk else None,
+            "mappings": mappings,
+            "backticked": m.group(1) == "`",
+        }
+
+    return {
+        "code": code,
+        "number": int(code[1:]) if code else None,
+        "name": name,
+        "file": str(path.relative_to(REPO_ROOT)),
+        "volume": path.parent.name,
+        "subtitle": subtitle,
+        "overview": overview,
+        "cards": cards,
+    }
+
+
+def build_taxonomy() -> dict:
+    """Merge every chapter's overview + cards into the full taxonomy object."""
+    tactics = []
+    for _, path in tactic_files().items():
+        ch = parse_chapter(path)
+        techniques = []
+        for row in ch["overview"]:
+            card = ch["cards"].get(row["id"], {})
+            techniques.append(
+                {
+                    "id": row["id"],
+                    "title": row["title"],
+                    "risk_score": row["risk_score"],
+                    "rating": row["rating"],
+                    "procedures": row["procedures"],
+                    "mappings": card.get(
+                        "mappings",
+                        {"owasp_llm": [], "owasp_asi": [], "mitre_atlas": []},
+                    ),
+                }
+            )
+        tactics.append(
+            {
+                "id": ch["code"],
+                "number": ch["number"],
+                "name": ch["name"],
+                "volume": ch["volume"],
+                "file": ch["file"],
+                "technique_count": len(techniques),
+                "techniques": techniques,
+            }
+        )
+
+    total_t = sum(t["technique_count"] for t in tactics)
+    total_p = sum((x["procedures"] or 0) for t in tactics for x in t["techniques"])
+    return {
+        "framework": "AATMF",
+        "name": "Adversarial AI Threat Modeling Framework",
+        "version": "3",
+        "source": "generated from docs/ by scripts/build_export.py — do not edit by hand",
+        "risk_scale": [{"min": lo, "rating": r, "emoji": e} for lo, r, e in RISK_SCALE],
+        "counts": {"tactics": len(tactics), "techniques": total_t, "procedures": total_p},
+        "tactics": tactics,
+    }
+
+
+def serialize_json(taxonomy: dict) -> str:
+    """Canonical JSON serialization shared by the exporter and the validator."""
+    return json.dumps(taxonomy, ensure_ascii=False, indent=2) + "\n"
+
+
+def parse_readme() -> dict:
+    text = README.read_text(encoding="utf-8")
+    tactics = {
+        m.group(1): {"name": _unescape(m.group(2)), "count": int(m.group(3))}
+        for m in _README_ROW_RE.finditer(text)
+    }
+    totals = None
+    if (tot := _README_TOTALS_RE.search(text)):
+        totals = {
+            "tactics": int(tot.group(1)),
+            "techniques": int(tot.group(2)),
+            "procedures": int(tot.group(3).replace(",", "")),
+        }
+    return {"tactics": tactics, "totals": totals}
+
+
+_LINK_RE = re.compile(r"\]\(([^)]+)\)")
+_HREF_RE = re.compile(r'(?:href|src)="([^"]+)"')
+
+
+def local_links(path: Path):
+    """Yield the relative (non-external, non-anchor) link targets in a file."""
+    text = Path(path).read_text(encoding="utf-8")
+    for link in set(_LINK_RE.findall(text)) | set(_HREF_RE.findall(text)):
+        if link.startswith(("http://", "https://", "#", "mailto:")):
+            continue
+        yield link

--- a/scripts/build_export.py
+++ b/scripts/build_export.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Generate the machine-readable AATMF taxonomy under data/.
+
+Outputs:
+  data/aatmf.json            — full nested taxonomy (tactics -> techniques -> mappings)
+  data/aatmf-techniques.csv  — flat technique table (spreadsheet / Navigator friendly)
+
+Run from anywhere:  python scripts/build_export.py
+"""
+
+import csv
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import aatmf_taxonomy as A  # noqa: E402
+
+
+def main() -> None:
+    taxonomy = A.build_taxonomy()
+    data_dir = A.REPO_ROOT / "data"
+    data_dir.mkdir(exist_ok=True)
+
+    (data_dir / "aatmf.json").write_text(A.serialize_json(taxonomy), encoding="utf-8")
+
+    with open(data_dir / "aatmf-techniques.csv", "w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(
+            [
+                "tactic_id", "tactic", "technique_id", "title",
+                "risk_score", "rating", "procedures", "owasp_llm", "mitre_atlas",
+            ]
+        )
+        for tactic in taxonomy["tactics"]:
+            for tech in tactic["techniques"]:
+                writer.writerow(
+                    [
+                        tactic["id"], tactic["name"], tech["id"], tech["title"],
+                        tech["risk_score"], tech["rating"], tech["procedures"],
+                        ";".join(tech["mappings"]["owasp_llm"]),
+                        ";".join(tech["mappings"]["mitre_atlas"]),
+                    ]
+                )
+
+    counts = taxonomy["counts"]
+    print(
+        f"Wrote data/aatmf.json and data/aatmf-techniques.csv "
+        f"({counts['tactics']} tactics, {counts['techniques']} techniques, "
+        f"{counts['procedures']} procedures)."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""AATMF framework integrity checks.
+
+Fails (exit 1) on structural defects that should never reach main:
+  * duplicate technique IDs
+  * per-tactic counts that disagree across docs, overview tables, and the README
+  * risk badges that don't match the AATMF-R scale
+  * overview/card risk-score drift
+  * broken relative links
+  * unbalanced code fences
+  * a stale data/ export
+
+Warnings (non-fatal) flag style drift worth cleaning up.
+
+Run from anywhere:  python scripts/validate.py
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import aatmf_taxonomy as A  # noqa: E402
+
+errors: list[str] = []
+warnings: list[str] = []
+
+
+def err(msg: str) -> None:
+    errors.append(msg)
+
+
+def warn(msg: str) -> None:
+    warnings.append(msg)
+
+
+def check_ids_and_counts(taxonomy, readme):
+    seen: dict[str, list[str]] = {}
+    for tactic in taxonomy["tactics"]:
+        for tech in tactic["techniques"]:
+            seen.setdefault(tech["id"], []).append(tactic["id"])
+    for tid, locs in seen.items():
+        if len(locs) > 1:
+            err(f"duplicate technique id {tid} appears in {locs}")
+
+    for tactic in taxonomy["tactics"]:
+        ch = A.parse_chapter(A.REPO_ROOT / tactic["file"])
+        n_over, n_card = len(ch["overview"]), len(ch["cards"])
+        declared = readme["tactics"].get(tactic["id"], {}).get("count")
+        if n_over != n_card:
+            err(f"{tactic['id']}: {n_over} overview rows but {n_card} technique cards")
+        if declared is not None and n_over != declared:
+            err(f"{tactic['id']}: docs list {n_over} techniques, README says {declared}")
+        if ch["subtitle"] and ch["subtitle"]["techniques"] != n_over:
+            err(
+                f"{tactic['id']}: subtitle claims {ch['subtitle']['techniques']} "
+                f"techniques, found {n_over}"
+            )
+        styles = {c["backticked"] for c in ch["cards"].values()}
+        if styles == {False}:
+            warn(
+                f"{tactic['id']}: technique headings omit the backtick convention "
+                f"(### `{tactic['id']}-AT-NNN`)"
+            )
+        elif len(styles) > 1:
+            err(f"{tactic['id']}: mixed technique-heading styles (backticked and not)")
+
+    totals = readme["totals"]
+    if totals:
+        if totals["techniques"] != taxonomy["counts"]["techniques"]:
+            err(
+                f"README headline says {totals['techniques']} techniques, "
+                f"docs contain {taxonomy['counts']['techniques']}"
+            )
+        table_sum = sum(v["count"] for v in readme["tactics"].values())
+        if table_sum != totals["techniques"]:
+            err(
+                f"README tactic-table sums to {table_sum}, "
+                f"headline says {totals['techniques']}"
+            )
+
+
+def check_risk_badges(taxonomy):
+    for tactic in taxonomy["tactics"]:
+        ch = A.parse_chapter(A.REPO_ROOT / tactic["file"])
+        overview_by_id = {r["id"]: r for r in ch["overview"]}
+        for row in ch["overview"]:
+            expected = A.rating_for(row["risk_score"])
+            if row["rating"] != expected:
+                err(
+                    f"{row['id']}: overview rating {row['rating']} should be "
+                    f"{expected} for score {row['risk_score']}"
+                )
+        for tid, card in ch["cards"].items():
+            if card["risk_score"] is not None and card["rating"]:
+                expected = A.rating_for(card["risk_score"])
+                if card["rating"] != expected:
+                    err(
+                        f"{tid}: card rating {card['rating']} should be "
+                        f"{expected} for score {card['risk_score']}"
+                    )
+            ov = overview_by_id.get(tid)
+            if ov and card["risk_score"] is not None and ov["risk_score"] != card["risk_score"]:
+                err(
+                    f"{tid}: overview score {ov['risk_score']} disagrees with "
+                    f"card score {card['risk_score']}"
+                )
+
+
+def check_links():
+    for path in [A.README, *sorted(A.DOCS.glob("**/*.md"))]:
+        for link in A.local_links(path):
+            target = link.split("#", 1)[0]
+            if not target:
+                continue
+            if not (path.parent / target).resolve().exists():
+                err(f"broken link in {path.relative_to(A.REPO_ROOT)} -> {link}")
+
+
+def check_fences():
+    for path in [A.README, *sorted(A.DOCS.glob("**/*.md"))]:
+        fences = sum(
+            1 for line in path.read_text(encoding="utf-8").splitlines()
+            if line.startswith("```")
+        )
+        if fences % 2:
+            err(f"unbalanced code fences in {path.relative_to(A.REPO_ROOT)} ({fences})")
+
+
+def check_export_fresh(taxonomy):
+    current = A.REPO_ROOT / "data" / "aatmf.json"
+    if not current.exists():
+        warn("data/aatmf.json missing — run scripts/build_export.py")
+        return
+    if current.read_text(encoding="utf-8") != A.serialize_json(taxonomy):
+        err("data/aatmf.json is stale — run scripts/build_export.py and commit the result")
+
+
+def main() -> None:
+    taxonomy = A.build_taxonomy()
+    readme = A.parse_readme()
+
+    check_ids_and_counts(taxonomy, readme)
+    check_risk_badges(taxonomy)
+    check_links()
+    check_fences()
+    check_export_fresh(taxonomy)
+
+    counts = taxonomy["counts"]
+    print("AATMF integrity check")
+    print(
+        f"  {counts['tactics']} tactics · {counts['techniques']} techniques · "
+        f"{counts['procedures']} procedures"
+    )
+    for w in warnings:
+        print(f"  WARN  {w}")
+    for e in errors:
+        print(f"  ERROR {e}")
+
+    if errors:
+        print(f"\nFAILED — {len(errors)} error(s), {len(warnings)} warning(s).")
+        sys.exit(1)
+    print(f"\nPASSED — 0 errors, {len(warnings)} warning(s).")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Dependency-free tooling (Python stdlib only) that makes the framework's structural invariants **machine-checkable** instead of hand-checked — plus a machine-readable export of the whole taxonomy. Implements two of the requested improvements: **CI integrity checks** and the **machine-readable export**.

## What's added
| Path | Purpose |
|:---|:---|
| `scripts/aatmf_taxonomy.py` | Shared Markdown parser → structured taxonomy (tactics, techniques, risk, OWASP/MITRE mappings). Tolerant of both heading styles. |
| `scripts/build_export.py` | Emits `data/aatmf.json` (nested) + `data/aatmf-techniques.csv` (flat). |
| `scripts/validate.py` | Integrity checks; exits 1 on failure. |
| `.github/workflows/integrity.yml` | Runs validation + export-freshness on every push & PR. |
| `data/aatmf.json`, `data/aatmf-techniques.csv` | Generated export — **15 tactics · 240 techniques · 2,152 procedures**. |

## What `validate.py` blocks
Duplicate technique IDs · per-tactic count drift across overview tables / cards / chapter subtitle / README · risk badges that don't match the AATMF-R scale · overview-vs-card score drift · broken relative links · unbalanced code fences · a stale `data/` export.

## Consistency fixes the new validator surfaced
- **Normalized T3 + T14 technique headings** to the `` ### `TX-AT-NNN` `` backtick convention used by the other 13 chapters (they were the only two without it).
- **Fixed the `T9-AT-017` overview-table badge** (248 = HIGH, not CRITICAL). The earlier card fix had corrected the technique card but missed the overview row at the top of the chapter — exactly the kind of half-fix this check now prevents. ✅

## Why this is worth it
The doubled-T9 corruption and the half-applied badge fix both reached `main` because nothing checked for them. This turns every check I'd been running by hand into a gate. The JSON/CSV export is the foundation for an ATT&CK-Navigator-style matrix and SIEM/tooling integrations.

`python scripts/validate.py` → **PASSED — 0 errors, 0 warnings.**

https://claude.ai/code/session_016chWYZxZhMC93ASr9Xss9w

---
_Generated by [Claude Code](https://claude.ai/code/session_016chWYZxZhMC93ASr9Xss9w)_