### PR TITLE
review: fix dangling T11 ref + unverified figure, harden validator

### DIFF
--- a/docs/vol-2-core-tactics/11-t08-deception.md
+++ b/docs/vol-2-core-tactics/11-t08-deception.md
@@ -30,7 +30,7 @@
 
 Deepfake fraud reached **$1.1 billion in 2025** (3x from 2024). Voice phishing surged **442%**. Notable: Arup $25.5M deepfake video call theft, Ferrari CEO voice clone, Italian defense minister impersonation.
 
-**North Korean IT worker infiltrations** grew 220%, generating $250M–$600M annually. Synthetic interview identity created in **70 minutes**.
+**North Korean IT worker infiltrations** grew 220%, generating $250M–$600M annually.
 
 AI-generated CSAM reports: **440,419 in H1 2025** (624% increase from all of 2024).
 
@@ -1351,7 +1351,7 @@ False-crisis content is a high-velocity trigger that supercharges other techniqu
 
 #### Mechanism
 
-Identity fabrication uses LLMs to construct complete, internally consistent false personas: full life histories, professional backgrounds, social-media post histories, believable biographies, credential and employment records, synthetic social networks, academic records, and references. It works because a persona's credibility comes from coherent breadth across many surfaces — a profile that posts plausibly over time, has a consistent backstory, and is embedded in a network reads as a real person. LLMs make manufacturing that breadth cheap and consistent, and can backfill years of plausible "history" in minutes. The asymmetry is between rapid generation of many rich, distinct identities and the cost of verifying each one against authoritative records. Moderation gaps are central: any single profile element is unremarkable, so detection must rely on provenance, network structure, and behavioral signals rather than content. The trust exploited is identity itself — the assumption that an account with a detailed, consistent history corresponds to a genuine, accountable person. This is the persona-supply layer behind sock-puppet and infiltration operations, including synthetic-interview identities reportedly stood up in as little as 70 minutes.
+Identity fabrication uses LLMs to construct complete, internally consistent false personas: full life histories, professional backgrounds, social-media post histories, believable biographies, credential and employment records, synthetic social networks, academic records, and references. It works because a persona's credibility comes from coherent breadth across many surfaces — a profile that posts plausibly over time, has a consistent backstory, and is embedded in a network reads as a real person. LLMs make manufacturing that breadth cheap and consistent, and can backfill years of plausible "history" in minutes. The asymmetry is between rapid generation of many rich, distinct identities and the cost of verifying each one against authoritative records. Moderation gaps are central: any single profile element is unremarkable, so detection must rely on provenance, network structure, and behavioral signals rather than content. The trust exploited is identity itself — the assumption that an account with a detailed, consistent history corresponds to a genuine, accountable person. This is the persona-supply layer behind sock-puppet and infiltration operations, including synthetic-interview identities stood up rapidly.
 
 #### Attack Procedures
 

--- a/docs/vol-3-advanced-tactics/14-t11-agentic.md
+++ b/docs/vol-3-advanced-tactics/14-t11-agentic.md
@@ -669,7 +669,7 @@ Agents calibrate how cautiously to act based on their understanding of the envir
 
 #### Chaining
 
-Environment manipulation is a precondition softener: delivered via T1 prompt injection or T12 RAG poisoning, it lowers the agent's perceived consequences so subsequent T11-AT-002 tool chains, T11-AT-011 exfiltration, and T11-AT-022/016-style SSRF run without refusal. The "firewall disabled / air-gapped" claims directly enable T11-AT-010 lateral movement, and the spoofed-privilege claims (AP127E/AP127I) precede T11-AT-009 persistence attempts.
+Environment manipulation is a precondition softener: delivered via T1 prompt injection or T12 RAG poisoning, it lowers the agent's perceived consequences so subsequent T11-AT-002 tool chains, T11-AT-011 exfiltration, and T11-AT-016 SSRF run without refusal. The "firewall disabled / air-gapped" claims directly enable T11-AT-010 lateral movement, and the spoofed-privilege claims (AP127E/AP127I) precede T11-AT-009 persistence attempts.
 
 #### Detection
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -25,6 +25,7 @@ python scripts/validate.py       # run integrity checks (exit 1 on failure)
   150–199 MEDIUM · 100–149 LOW · 0–99 INFO)
 - Overview/card risk-score drift
 - Broken relative links
+- Undefined inline technique references (`TX-AT-NNN` with no matching card)
 - Unbalanced code fences
 - A stale `data/` export
 

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -135,6 +135,27 @@ def check_export_fresh(taxonomy):
         err("data/aatmf.json is stale — run scripts/build_export.py and commit the result")
 
 
+def check_inline_refs(taxonomy):
+    """Flag inline TX-AT-NNN references that don't resolve to a defined technique."""
+    import re
+
+    defined = set()
+    for tactic in taxonomy["tactics"]:
+        for tech in tactic["techniques"]:
+            m = re.match(r"T(\d+)-AT-(\d+)", tech["id"])
+            defined.add((int(m.group(1)), int(m.group(2))))
+
+    seen: dict[str, set] = {}
+    for path in [A.README, *sorted(A.DOCS.glob("**/*.md"))]:
+        for m in re.finditer(r"\bT(\d+)-AT-(\d+)\b", path.read_text(encoding="utf-8")):
+            key = (int(m.group(1)), int(m.group(2)))
+            if key not in defined:
+                rid = f"T{m.group(1)}-AT-{m.group(2)}"
+                seen.setdefault(rid, set()).add(str(path.relative_to(A.REPO_ROOT)))
+    for rid, locs in sorted(seen.items()):
+        err(f"reference to undefined technique {rid} in {sorted(locs)}")
+
+
 def main() -> None:
     taxonomy = A.build_taxonomy()
     readme = A.parse_readme()
@@ -143,6 +164,7 @@ def main() -> None:
     check_risk_badges(taxonomy)
     check_links()
     check_fences()
+    check_inline_refs(taxonomy)
     check_export_fresh(taxonomy)
 
     counts = taxonomy["counts"]


### PR DESCRIPTION
## Review findings + fixes

A post-merge review of the T8/T11/T15 expansion (focused on what CI can't see: cross-references, fabricated specifics, content quality).

**Fixed here:**
1. **Dangling reference** — T11 card 007 chaining cited `T11-AT-022`, which doesn't exist (T11 ends at 016). Corrected to `T11-AT-016` (SSRF).
2. **Unverifiable figure** — T8 carried an agent-added "synthetic interview identity created in 70 minutes" claim that wasn't in the source material and can't be verified. Removed from the threat banner; generalized in the mechanism text. *(All other quantitative claims — CSAM 440,419; 442% vishing; NK IT workers; MCP 84.2% ASR; the CVEs; T15's 10–42% — were verified as the maintainer's **preserved** threat-intel and kept.)*
3. **Tooling gap** — `validate.py` didn't catch the dangling ref. Added an **inline technique-reference check** (every `TX-AT-NNN` mention must resolve to a defined card); proven to catch a synthetic `T11-AT-099`. This class is now blocked in CI.

**Clean:** all 418 AP cross-references resolve; no other dangling refs repo-wide; `validate.py` → **0 errors, 0 warnings**.

https://claude.ai/code/session_016chWYZxZhMC93ASr9Xss9w

---
_Generated by [Claude Code](https://claude.ai/code/session_016chWYZxZhMC93ASr9Xss9w)_